### PR TITLE
Correct Netty client instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/datastax-cassandra-2.3/datastax-cassandra-2.3.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-2.3/datastax-cassandra-2.3.gradle
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 // Set properties before any plugins get loaded
 ext {
   // Test use Cassandra 3 which requires Java 8. (Currently incompatible with Java 9.)
@@ -37,5 +38,5 @@ dependencies {
   testCompile group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.2.0'
   testCompile group: 'org.cassandraunit', name: 'cassandra-unit', version: '3.1.3.2'
 
-  latestDepTestCompile group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '+'
+  latestDepTestCompile group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.+'
 }

--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 // Set properties before any plugins get loaded
 project.ext {
   // Execute tests on all JVMs, even rare and outdated ones
@@ -35,7 +36,7 @@ dependencies {
   testCompile group: 'com.mchange', name: 'c3p0', version: '0.9.5'
   
   latestDepTestCompile group: 'com.h2database', name: 'h2', version: '+'
-  latestDepTestCompile group: 'org.apache.derby', name: 'derby', version: '+'
+  latestDepTestCompile group: 'org.apache.derby', name: 'derby', version: '10.14.+'
   latestDepTestCompile group: 'org.hsqldb', name: 'hsqldb', version: '+'
 
   latestDepTestCompile group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: '+'

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/AttributeKeys.java
@@ -1,6 +1,8 @@
+// Modified by SignalFx
 package datadog.trace.instrumentation.netty40;
 
 import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.netty40.client.HttpClientTracingHandler;
 import datadog.trace.instrumentation.netty40.server.HttpServerTracingHandler;
 import io.netty.util.AttributeKey;
 import io.opentracing.Span;
@@ -14,5 +16,5 @@ public class AttributeKeys {
       new AttributeKey<>(HttpServerTracingHandler.class.getName() + ".span");
 
   public static final AttributeKey<Span> CLIENT_ATTRIBUTE_KEY =
-      new AttributeKey<>(HttpServerTracingHandler.class.getName() + ".span");
+      new AttributeKey<>(HttpClientTracingHandler.class.getName() + ".span");
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package datadog.trace.instrumentation.netty40;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
@@ -42,6 +43,11 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".AttributeKeys",
+      // client helpers
+      packageName + ".client.NettyResponseInjectAdapter",
+      packageName + ".client.HttpClientRequestTracingHandler",
+      packageName + ".client.HttpClientResponseTracingHandler",
+      packageName + ".client.HttpClientTracingHandler",
       // server helpers
       packageName + ".server.NettyRequestExtractAdapter",
       packageName + ".server.HttpServerRequestTracingHandler",

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/AttributeKeys.java
@@ -1,6 +1,8 @@
+// Modified by SignalFx
 package datadog.trace.instrumentation.netty41;
 
 import datadog.trace.context.TraceScope;
+import datadog.trace.instrumentation.netty41.client.HttpClientTracingHandler;
 import datadog.trace.instrumentation.netty41.server.HttpServerTracingHandler;
 import io.netty.util.AttributeKey;
 import io.opentracing.Span;
@@ -14,5 +16,5 @@ public class AttributeKeys {
       AttributeKey.valueOf(HttpServerTracingHandler.class.getName() + ".span");
 
   public static final AttributeKey<Span> CLIENT_ATTRIBUTE_KEY =
-      AttributeKey.valueOf(HttpServerTracingHandler.class.getName() + ".span");
+      AttributeKey.valueOf(HttpClientTracingHandler.class.getName() + ".span");
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/ChannelFutureListenerInstrumentation.java
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package datadog.trace.instrumentation.netty41;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
@@ -42,6 +43,11 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".AttributeKeys",
+      // client helpers
+      packageName + ".client.NettyResponseInjectAdapter",
+      packageName + ".client.HttpClientRequestTracingHandler",
+      packageName + ".client.HttpClientResponseTracingHandler",
+      packageName + ".client.HttpClientTracingHandler",
       // server helpers
       packageName + ".server.NettyRequestExtractAdapter",
       packageName + ".server.HttpServerRequestTracingHandler",


### PR DESCRIPTION
Netty client tracing handler instrumentation is failing due to redundant attribute key value (should be client):
```
Caused by: java.lang.IllegalArgumentException: 'datadog.trace.instrumentation.netty40.server.HttpServerTracingHandler.span' is already in use
```
These changes correct this oversight and include necessary helper class injections.

Also pinning failing latest dependency test versions until they can be examined.