### PR TITLE
Add Netty relocated package gradle property

### DIFF
--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -58,6 +58,10 @@ configurations {
 }
 
 shadowJar {
+  if (project.hasProperty('relocatedNettyPackage')) {
+    relocate 'io.netty', project.property('relocatedNettyPackage').toString()
+  }
+
   dependencies {
     exclude(project(':dd-java-agent:agent-bootstrap'))
     exclude(project(':dd-trace-api'))


### PR DESCRIPTION
Will allow shade/shadow users to build an agent with nonstandard Netty package path:

`./gradlew build -PrelocatedNettyPackage='my.shaded.package.path.netty'`