### PR TITLE
Add @TraceSetting and whitelist jax-rs-controller exceptions

### DIFF
--- a/dd-trace-api/src/main/java/com/signalfx/tracing/api/TraceSetting.java
+++ b/dd-trace-api/src/main/java/com/signalfx/tracing/api/TraceSetting.java
@@ -1,0 +1,69 @@
+package com.signalfx.tracing.api;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/** Use this annotation for class and method per-instrumentation configurations */
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+public @interface TraceSetting {
+
+  /** Helper class to operate on potentially annotated AnnotatedElements */
+  class Annotated {
+
+    /** Retrieves any annotated TraceSettings up the inheritance chain. */
+    private static List<TraceSetting> getAllTraceSettings(AnnotatedElement target) {
+      ArrayList<TraceSetting> traceSettings = new ArrayList<>();
+
+      final TraceSetting applied = target.getAnnotation(TraceSetting.class);
+      if (applied != null) {
+        traceSettings.add(applied);
+      }
+
+      Class<?> klass;
+      if (target instanceof Method) {
+        klass = ((Method) target).getDeclaringClass();
+      } else if (target instanceof Class) {
+        klass = ((Class) target).getSuperclass();
+      } else { // Unsupported interface or enum.
+        klass = Object.class;
+      }
+
+      // Go up the inheritance chain and get all TraceSettings
+      while (klass != Object.class) {
+        final TraceSetting traceSetting = klass.getAnnotation(TraceSetting.class);
+        if (traceSetting != null) {
+          traceSettings.add(traceSetting);
+        }
+        klass = klass.getSuperclass();
+      }
+
+      return traceSettings;
+    }
+
+    /**
+     * Get a list of Exception classes specified by the allowedExceptions element for target, its
+     * class (if method), and all super classes.
+     */
+    public static List<Class> getAllowedExceptions(AnnotatedElement target) {
+      List<TraceSetting> traceSettings = getAllTraceSettings(target);
+      ArrayList<Class> allowedExceptions = new ArrayList<>();
+      for (final TraceSetting traceSetting : traceSettings) {
+        allowedExceptions.addAll(Arrays.asList(traceSetting.allowedExceptions()));
+      }
+      return allowedExceptions;
+    }
+  }
+
+  /** An array of Exceptions to not error tag in instrumentations. */
+  Class[] allowedExceptions() default {};
+}

--- a/dd-trace-api/src/test/groovy/com/signalfx/tracing/TraceSettingTest.groovy
+++ b/dd-trace-api/src/test/groovy/com/signalfx/tracing/TraceSettingTest.groovy
@@ -1,0 +1,95 @@
+// Modified by SignalFx
+package com.signalfx.tracing
+
+import com.signalfx.tracing.api.TraceSetting
+import spock.lang.*
+
+class TraceSettingTest extends Specification {
+
+  static class CustomException extends Exception {}
+
+  static class OtherCustomException extends CustomException {}
+
+  static class AnotherCustomException extends Exception {}
+
+  static class YetAnotherCustomException extends Exception {}
+
+  @TraceSetting(allowedExceptions = [CustomException])
+  static class AnnotatedClass {
+    @TraceSetting(allowedExceptions = [OtherCustomException])
+    static void annotatedMethod() {}
+
+    static void nonAnnotatedMethod() {}
+  }
+
+  static class NonAnnotatedClass {
+    @TraceSetting(allowedExceptions = [OtherCustomException])
+    static void annotatedMethod() {}
+
+    static void nonAnnotatedMethod() {}
+  }
+
+  @TraceSetting(allowedExceptions = [AnotherCustomException])
+  static class AnotherAnnotatedClass extends AnnotatedClass {
+    @TraceSetting(allowedExceptions = [YetAnotherCustomException])
+    static void annotatedMethod() {}
+  }
+
+  def "Non-annotated classes have empty allowedExceptions"() {
+    setup:
+    def allowedExceptions = TraceSetting.Annotated.getAllowedExceptions(NonAnnotatedClass)
+
+    expect:
+    allowedExceptions == []
+  }
+
+  def "Non-annotated methods have empty allowedExceptions"() {
+    setup:
+    def allowedExceptions = TraceSetting.Annotated.getAllowedExceptions(NonAnnotatedClass.getMethod('nonAnnotatedMethod'))
+
+    expect:
+    allowedExceptions == []
+  }
+
+  def "Non-annotated methods have class allowedExceptions"() {
+    setup:
+    def allowedExceptions = TraceSetting.Annotated.getAllowedExceptions(AnnotatedClass.getMethod('nonAnnotatedMethod'))
+
+    expect:
+    allowedExceptions == [CustomException]
+  }
+
+  def "Annotated classes have allowedExceptions"() {
+    setup:
+    def allowedExceptions = TraceSetting.Annotated.getAllowedExceptions(AnnotatedClass)
+
+    expect:
+    allowedExceptions == [CustomException]
+  }
+
+  def "Annotated methods have allowedExceptions"() {
+    setup:
+    def allowedExceptions = TraceSetting.Annotated.getAllowedExceptions(NonAnnotatedClass.getMethod('annotatedMethod'))
+
+    expect:
+    allowedExceptions == [OtherCustomException]
+  }
+
+  def "Annotated class and methods combine allowedExceptions"() {
+    setup:
+    println(AnnotatedClass.getProperties().toString())
+    def allowedExceptions = TraceSetting.Annotated.getAllowedExceptions(AnnotatedClass.getMethod('annotatedMethod'))
+
+    expect:
+    allowedExceptions == [OtherCustomException, CustomException]
+  }
+
+  def "Annotated superclass and methods combine allowedExceptions"() {
+    setup:
+    println(AnnotatedClass.getProperties().toString())
+    def allowedExceptions = TraceSetting.Annotated.getAllowedExceptions(AnotherAnnotatedClass.getMethod('annotatedMethod'))
+
+    expect:
+    allowedExceptions == [YetAnotherCustomException, AnotherCustomException, CustomException]
+  }
+}


### PR DESCRIPTION
These changes introduce the `@TraceSetting` annotation for lower-level instrumentation configuration.  For the first provided feature, an `allowedExceptions` exception class array element will be used in determining whether to mark `jax-rs-controller` spans has having errored.

```
import com.signalfx.trace.api.TraceSetting;

@GET
@TraceSetting(allowedExceptions = {MyCustomException.class}
public void handle() throws MyCustomException {
  // This JAX resource will not be marked with error tags
  throw new MyCustomException();
}
```