### PR TITLE
Enable Jetty server instrumentation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ given in the table below.
 | **JDBC API** | * | `jdbc` | |
 | **Jedis (Redis client)** | 1.4.0+ | `jedis` | |
 | **Lettuce (Redis Client)** | 5.0.0+ | `lettuce` | |
-| _Jetty Server_ | 8.0.0+ | `jetty` | |
+| **Jetty Server** | 8.0.0+ | `jetty` | |
 | **JMS Messaging** | * | `jms` | |
 | **JSP** | 7+ | `jsp` | |
 | **Kafka Client** | 0.11.0.0+ | `kafka` | |

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/HandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/HandlerInstrumentation.java
@@ -1,3 +1,4 @@
+//Modified by SignalFx
 package datadog.trace.instrumentation.jetty8;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
@@ -20,11 +21,6 @@ public final class HandlerInstrumentation extends Instrumenter.Default {
 
   public HandlerInstrumentation() {
     super("jetty", "jetty-8");
-  }
-
-  @Override
-  public boolean defaultEnabled() {
-    return false;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -1,3 +1,4 @@
+//Modified by SignalFx
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
@@ -18,10 +19,6 @@ import javax.servlet.http.HttpServletResponse
 import java.util.concurrent.atomic.AtomicBoolean
 
 class JettyHandlerTest extends AgentTestRunner {
-
-  static {
-    System.setProperty("dd.integration.jetty.enabled", "true")
-  }
 
   int port = PortUtils.randomOpenPort()
   Server server = new Server(port)

--- a/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
+++ b/dd-java-agent/instrumentation/servlet-3/servlet-3.gradle
@@ -1,3 +1,4 @@
+//Modified by SignalFx
 muzzle {
   pass {
     group = "javax.servlet"
@@ -46,4 +47,8 @@ dependencies {
   latestDepTestCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '+'
   latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '+'
   latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '+'
+}
+
+tasks.withType(Test).configureEach {
+  jvmArgs "-Dsignalfx.integration.jetty.enabled=false"
 }


### PR DESCRIPTION
Updates the default enabled status for Jetty except for servlet 3 tests, which would need updating for effectively redundant spans.