### PR TITLE
Ensure Zipkin writers input stream closes

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
@@ -52,18 +52,19 @@ public class ZipkinV2Api implements Api {
       out.close();
 
       final int responseCode = httpCon.getResponseCode();
+
+      final BufferedReader responseReader =
+          new BufferedReader(
+              new InputStreamReader(httpCon.getInputStream(), StandardCharsets.UTF_8));
+      final StringBuilder sb = new StringBuilder();
+
+      String line;
+      while ((line = responseReader.readLine()) != null) {
+        sb.append(line);
+      }
+      responseReader.close();
+
       if (responseCode != 200) {
-        final BufferedReader responseReader =
-            new BufferedReader(
-                new InputStreamReader(httpCon.getInputStream(), StandardCharsets.UTF_8));
-        final StringBuilder sb = new StringBuilder();
-
-        String line;
-        while ((line = responseReader.readLine()) != null) {
-          sb.append(line);
-        }
-        responseReader.close();
-
         log.warn("Bad response code sending traces to {}: {}", traceEndpoint, sb.toString());
       } else {
         log.debug("Successfully sent {} traces", traces.size());


### PR DESCRIPTION
These changes address that we are only releasing connection resources on non-200 status codes for Zipkin trace submission:

URLConnection.java:
```
...
 * Invoking the {@code close()} methods on the {@code InputStream} or {@code OutputStream} of an
 * {@code URLConnection} after a request may free network resources associated with this
...
```