### PR TITLE
Provide informative Zipkin span names for web servers

### DIFF
--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
@@ -49,8 +49,8 @@ public class JettyHandlerAdvice {
     final Span span = scope.span();
     Tags.COMPONENT.set(span, "jetty-handler");
     Tags.HTTP_METHOD.set(span, req.getMethod());
-    Tags.HTTP_URL.set(span, req.getRequestURL().toString());
     span.setTag(DDTags.RESOURCE_NAME, resourceName);
+    Tags.HTTP_URL.set(span, req.getRequestURL().toString());
     if (req.getUserPrincipal() != null) {
       span.setTag(DDTags.USER_NAME, req.getUserPrincipal().getName());
     }

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -56,7 +56,7 @@ class JettyHandlerTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "jetty.request"
-          resourceName "GET ${handler.class.name}"
+          resourceName "GET /"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           parent()
@@ -113,7 +113,7 @@ class JettyHandlerTest extends AgentTestRunner {
           span(0) {
             serviceName "unnamed-java-app"
             operationName "jetty.request"
-            resourceName "GET ${handler.class.name}"
+            resourceName "GET /"
           }
         }
       }
@@ -150,7 +150,7 @@ class JettyHandlerTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "jetty.request"
-          resourceName "GET ${handler.class.name}"
+          resourceName "GET /"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           parent()
@@ -172,7 +172,7 @@ class JettyHandlerTest extends AgentTestRunner {
           span(0) {
             serviceName "unnamed-java-app"
             operationName "jetty.request"
-            resourceName "GET ${handler.class.name}"
+            resourceName "GET /"
             spanType DDSpanTypes.HTTP_SERVER
             errored true
             parent()

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/ZipkinV2ApiTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/ZipkinV2ApiTest.groovy
@@ -102,7 +102,7 @@ class ZipkinV2ApiTest extends Specification {
       "kind"    : null,
       "timestamp"    : 100,
     ])]
-    [[SpanFactory.newSpanOf(100L).setTag("span.kind", "CLIENT")]] | [new TreeMap<>([
+    [[SpanFactory.newSpanOf(100L).setTag("span.kind", "CliEnt")]] | [new TreeMap<>([
       "traceId" : "0000000000000001",
       "id"  :     "0000000000000001",
       "parentId": "0000000000000000",
@@ -113,7 +113,21 @@ class ZipkinV2ApiTest extends Specification {
                     "resource.name": "fakeResource"],
       "name"     : "fakeOperation",
       "localEndpoint": ["serviceName": "fakeService"],
-      "kind"    : "CLIENT",
+      "kind"    : "CliEnt",
+      "timestamp"    : 100,
+    ])]
+    [[SpanFactory.newSpanOf(100L).setTag("span.kind", "SerVeR")]] | [new TreeMap<>([
+      "traceId" : "0000000000000001",
+      "id"  :     "0000000000000001",
+      "parentId": "0000000000000000",
+      "duration" : 0,
+      "tags"     : ["thread.name": Thread.currentThread().getName(),
+                    "thread.id": "${Thread.currentThread().id}",
+                    "span.type": "fakeType",
+                    "resource.name": "fakeResource"],
+      "name"     : "fakeResource",
+      "localEndpoint": ["serviceName": "fakeService"],
+      "kind"    : "SerVeR",
       "timestamp"    : 100,
     ])]
   }


### PR DESCRIPTION
Web servers currently have extremely limited operation names that cause undesired grouping of dissimilar traces.  These changes take advantage of the normalizing and 404 path-masking resource name decorators for http.url tag values and update the Zipkin span names to be more specific.

If some service owners are using non-standard paths that don't match [the mixed alphanumeric pattern](https://github.com/signalfx/signalfx-java-tracing/blob/master/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java#L15), replacing operation name in gateway could be necessary: https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.signalfx.gateway.html#identify-and-replace-variables-in-span-names.