### PR TITLE
Set span sampling priority in AllSampler

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -15,6 +15,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.common.sampling.AllSampler;
 import datadog.trace.common.sampling.RateByServiceSampler;
 import datadog.trace.common.sampling.Sampler;
 import datadog.trace.common.writer.DDAgentWriter;
@@ -488,6 +489,8 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
       final DDSpan span = new DDSpan(timestampMicro, buildSpanContext());
       if (sampler instanceof RateByServiceSampler) {
         ((RateByServiceSampler) sampler).initializeSamplingPriority(span);
+      } else if (sampler instanceof AllSampler) {
+        ((AllSampler) sampler).initializeSamplingPriority(span);
       }
       return span;
     }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/propagation/B3HttpCodec.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/propagation/B3HttpCodec.java
@@ -44,19 +44,21 @@ public class B3HttpCodec implements Injector, Extractor {
       carrier.put(PARENT_SPAN_ID_KEY, Ids.idToHex(context.getParentId()));
     }
 
-    int ps = context.getSamplingPriority();
-    switch (ps) {
-      case PrioritySampling.USER_KEEP:
-        // Set the debug flag if the user has manually marked the span to keep
-        carrier.put(FLAGS_KEY, "1");
-        // We don't need to set sampled in this case since it is implied
-        break;
-      case PrioritySampling.SAMPLER_KEEP:
-        carrier.put(SAMPLED_KEY, "1");
-        break;
-      case PrioritySampling.SAMPLER_DROP:
-      case PrioritySampling.USER_DROP:
-        carrier.put(SAMPLED_KEY, "0");
+    if (context.lockSamplingPriority()) {
+      int ps = context.getSamplingPriority();
+      switch (ps) {
+        case PrioritySampling.USER_KEEP:
+          // Set the debug flag if the user has manually marked the span to keep
+          carrier.put(FLAGS_KEY, "1");
+          // We don't need to set sampled in this case since it is implied
+          break;
+        case PrioritySampling.SAMPLER_KEEP:
+          carrier.put(SAMPLED_KEY, "1");
+          break;
+        case PrioritySampling.SAMPLER_DROP:
+        case PrioritySampling.USER_DROP:
+          carrier.put(SAMPLED_KEY, "0");
+      }
     }
 
     for (final Map.Entry<String, String> entry : context.baggageItems()) {

--- a/dd-trace-ot/src/main/java/datadog/trace/common/sampling/AllSampler.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/sampling/AllSampler.java
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package datadog.trace.common.sampling;
 
 import datadog.opentracing.DDSpan;
@@ -8,6 +9,13 @@ public class AllSampler extends AbstractSampler {
   @Override
   public boolean doSample(final DDSpan span) {
     return true;
+  }
+
+  /** Injected sampling flags are based on sampling priority, so always keep */
+  public void initializeSamplingPriority(DDSpan span) {
+    if (span.isRootSpan() || span.getSamplingPriority() == null) {
+      span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
+    }
   }
 
   @Override


### PR DESCRIPTION
Span propagation flags are determined during injection by the sampling priority of the root span.  Using the `AllSampler` bypasses the priority sampling mechanism such that it's always "unset".  These changes add the required initialization process to the tracer and setter in the sampler.  Resolves the issue of not providing the B3 sampled header and deferring to remote services' tracer implementation.