### PR TITLE
Update Byte Buddy dependency to 1.9.12

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 def groovyVer = "2.5.2"
 def spockGroovyVer = groovyVer.replaceAll(/\.\d+$/, '')
 
@@ -14,7 +15,7 @@ ext {
     junit      : "4.12",
     logback    : "1.2.3",
     lombok     : "1.18.4",
-    bytebuddy  : "1.9.9",
+    bytebuddy  : "1.9.12",
     scala      : "2.11.12",
     kotlin     : "1.3.11",
     coroutines : "1.1.0"


### PR DESCRIPTION
Resolves https://github.com/signalfx/signalfx-java-tracing/issues/28 to pull in JDK12-compatible Byte Buddy version.