### PR TITLE
Include tracer version in global tags

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -75,6 +75,15 @@ public class Config {
   public static final String LANGUAGE_TAG_VALUE = "jvm";
   public static final String DEFAULT_SERVICE_NAME = "unnamed-java-app";
 
+  public static final String TRACING_LIBRARY_KEY = "signalfx.tracing.library";
+  public static final String TRACING_LIBRARY_VALUE = "java-tracing";
+  public static final String TRACING_VERSION_KEY = "signalfx.tracing.version";
+  public static final String TRACING_VERSION_VALUE = "0.24.0-sfx9";
+  public static final String DEFAULT_GLOBAL_TAGS =
+      String.format(
+          "%s:%s,%s:%s",
+          TRACING_LIBRARY_KEY, TRACING_LIBRARY_VALUE, TRACING_VERSION_KEY, TRACING_VERSION_VALUE);
+
   public static final String DD_AGENT_WRITER_TYPE = "DDAgentWriter";
   public static final String DD_AGENT_API_TYPE = "DD";
   public static final String ZIPKIN_V2_API_TYPE = "ZipkinV2";
@@ -155,7 +164,7 @@ public class Config {
         getBooleanSettingFromEnvironment(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
     serviceMapping = getMapSettingFromEnvironment(SERVICE_MAPPING, null);
 
-    globalTags = getMapSettingFromEnvironment(GLOBAL_TAGS, null);
+    globalTags = getMapSettingFromEnvironment(GLOBAL_TAGS, DEFAULT_GLOBAL_TAGS);
     spanTags = getMapSettingFromEnvironment(SPAN_TAGS, null);
     jmxTags = getMapSettingFromEnvironment(JMX_TAGS, null);
     headerTags = getMapSettingFromEnvironment(HEADER_TAGS, null);

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -23,6 +23,10 @@ import static datadog.trace.api.Config.JMX_FETCH_STATSD_PORT
 import static datadog.trace.api.Config.JMX_TAGS
 import static datadog.trace.api.Config.LANGUAGE_TAG_KEY
 import static datadog.trace.api.Config.LANGUAGE_TAG_VALUE
+import static datadog.trace.api.Config.TRACING_LIBRARY_KEY
+import static datadog.trace.api.Config.TRACING_LIBRARY_VALUE
+import static datadog.trace.api.Config.TRACING_VERSION_KEY
+import static datadog.trace.api.Config.TRACING_VERSION_VALUE
 import static datadog.trace.api.Config.PARTIAL_FLUSH_MIN_SPANS
 import static datadog.trace.api.Config.PREFIX
 import static datadog.trace.api.Config.PRIORITY_SAMPLING
@@ -216,7 +220,7 @@ class ConfigTest extends Specification {
     config.prioritySamplingEnabled == false
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
-    config.mergedSpanTags == [:]
+    config.mergedSpanTags == [(TRACING_LIBRARY_KEY):TRACING_LIBRARY_VALUE, (TRACING_VERSION_KEY):TRACING_VERSION_VALUE]
     config.headerTags == [:]
     config.httpClientSplitByDomain == false
   }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package datadog.opentracing
 
 import datadog.opentracing.propagation.ExtractedContext
@@ -412,6 +413,8 @@ class DDSpanBuilderTest extends Specification {
       (DDTags.THREAD_ID)       : Thread.currentThread().getId(),
       (Config.RUNTIME_ID_TAG)  : config.getRuntimeId(),
       (Config.LANGUAGE_TAG_KEY): Config.LANGUAGE_TAG_VALUE,
+      (Config.TRACING_LIBRARY_KEY): Config.TRACING_LIBRARY_VALUE,
+      (Config.TRACING_VERSION_KEY): Config.TRACING_VERSION_VALUE
     ]
 
     cleanup:


### PR DESCRIPTION
Adds a library and version tag to the global defaults for reporting tracer information.