### PR TITLE
Implement span.log()

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
@@ -1,5 +1,8 @@
+// Modified by SignalFx
 package datadog.trace.api.interceptor;
 
+import java.util.AbstractMap;
+import java.util.List;
 import java.util.Map;
 
 public interface MutableSpan {
@@ -37,6 +40,16 @@ public interface MutableSpan {
   MutableSpan setTag(final String tag, final boolean value);
 
   MutableSpan setTag(final String tag, final Number value);
+
+  List<AbstractMap.SimpleEntry<Long, Map<String, ?>>> getLogs();
+
+  MutableSpan log(final java.util.Map<java.lang.String, ?> map);
+
+  MutableSpan log(final long l, final java.util.Map<java.lang.String, ?> map);
+
+  MutableSpan log(final java.lang.String s);
+
+  MutableSpan log(final long l, final java.lang.String s);
 
   Boolean isError();
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
@@ -1,6 +1,10 @@
+// Modified by SignalFx
 package datadog.opentracing;
 
+import static io.opentracing.log.Fields.ERROR_KIND;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
+import static io.opentracing.log.Fields.MESSAGE;
+import static io.opentracing.log.Fields.STACK;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -18,7 +22,10 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.ref.WeakReference;
 import java.math.BigInteger;
+import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -143,10 +150,14 @@ public class DDSpan implements Span, MutableSpan {
   }
 
   private boolean extractError(final Map<String, ?> map) {
-    if (map.get(ERROR_OBJECT) instanceof Throwable) {
-      final Throwable error = (Throwable) map.get(ERROR_OBJECT);
-      setErrorMeta(error);
-      return true;
+    final Object errorObject = map.get(ERROR_OBJECT);
+    if (errorObject instanceof Throwable) {
+      // if custom instrumentation don't use setErrorMeta
+      if (!map.containsKey(ERROR_KIND) && !map.containsKey(MESSAGE) && !map.containsKey(STACK)) {
+        final Throwable error = (Throwable) errorObject;
+        setErrorMeta(error);
+        return true;
+      }
     }
     return false;
   }
@@ -217,8 +228,9 @@ public class DDSpan implements Span, MutableSpan {
    */
   @Override
   public final DDSpan log(final Map<String, ?> map) {
+    final long currentTime = Clock.currentMicroTime();
     if (!extractError(map)) {
-      log.debug("`log` method is not implemented. Doing nothing");
+      context().log(currentTime, map);
     }
     return this;
   }
@@ -229,7 +241,7 @@ public class DDSpan implements Span, MutableSpan {
   @Override
   public final DDSpan log(final long l, final Map<String, ?> map) {
     if (!extractError(map)) {
-      log.debug("`log` method is not implemented. Doing nothing");
+      context().log(l, map);
     }
     return this;
   }
@@ -239,7 +251,7 @@ public class DDSpan implements Span, MutableSpan {
    */
   @Override
   public final DDSpan log(final String s) {
-    log.debug("`log` method is not implemented. Provided log: {}", s);
+    this.log(Collections.singletonMap("event", s));
     return this;
   }
 
@@ -248,8 +260,14 @@ public class DDSpan implements Span, MutableSpan {
    */
   @Override
   public final DDSpan log(final long l, final String s) {
-    log.debug("`log` method is not implemented. Provided log: {}", s);
+    this.log(l, Collections.singletonMap("event", s));
     return this;
+  }
+
+  @Override
+  @JsonIgnore
+  public List<AbstractMap.SimpleEntry<Long, Map<String, ?>>> getLogs() {
+    return context().getLogs();
   }
 
   @Override

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
@@ -2,6 +2,7 @@ package datadog.trace.common.writer;
 
 import static io.opentracing.tag.Tags.SPAN_KIND;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -19,6 +20,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -133,6 +135,21 @@ public class ZipkinV2Api implements Api {
     }
 
     updateFromResourceTag(spanNode, tagNode);
+
+    ArrayNode annotations = spanNode.putArray("annotations");
+    for (AbstractMap.SimpleEntry<Long, Map<String, ?>> item : span.getLogs()) {
+      final ObjectNode annotation = objectMapper.createObjectNode();
+      annotation.put("timestamp", item.getKey());
+      JsonNode value = objectMapper.valueToTree(item.getValue());
+      try {
+        String encodedValue = objectMapper.writeValueAsString(value);
+        annotation.put("value", encodedValue);
+      } catch (JsonProcessingException e) {
+        log.warn("Failed creating annotation");
+        continue;
+      }
+      annotations.add(annotation);
+    }
 
     return spanNode;
   }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package datadog.opentracing
 
 import datadog.trace.api.sampling.PrioritySampling
@@ -195,5 +196,29 @@ class DDSpanTest extends Specification {
     cleanup:
     child.finish()
     root.finish()
+  }
+
+  def "span tags are settable"() {
+    setup:
+    def span = tracer.buildSpan("root").start()
+    def one = TimeUnit.MILLISECONDS.toMicros(1)
+    def two = TimeUnit.MILLISECONDS.toMicros(2)
+    def time = System.currentTimeMillis()
+
+    span.log(one, "some event")
+    span.log(two, ["my event": "event"])
+    span.log(two, ["my event": "another event"])
+    span.log(time, ["event" : true])
+
+    def expectedOne = new AbstractMap.SimpleEntry(one , ["event": "some event"])
+    def expectedTwo = new AbstractMap.SimpleEntry(two, ["my event": "event"])
+    def expectedThree = new AbstractMap.SimpleEntry(two, ["my event": "another event"])
+    def expectedFour = new AbstractMap.SimpleEntry(time, ["event" : true])
+
+    expect:
+    span.getLogs() == [expectedOne, expectedTwo, expectedThree, expectedFour]
+
+    cleanup:
+    span.finish()
   }
 }

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/ZipkinV2ApiTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/ZipkinV2ApiTest.groovy
@@ -74,7 +74,7 @@ class ZipkinV2ApiTest extends Specification {
     where:
     traces                                                               | expectedRequestBody
     []                                                                   | []
-    [[SpanFactory.newSpanOf(1L).setTag("service", "my-service")]]     | [new TreeMap<>([
+    [[SpanFactory.newSpanOf(1L).setTag("service", "my-service").log(1000L, "some event")]]     | [new TreeMap<>([
       "traceId" : "0000000000000001",
       "id"  :     "0000000000000001",
       "parentId": "0000000000000000",
@@ -83,6 +83,7 @@ class ZipkinV2ApiTest extends Specification {
                     "thread.id": "${Thread.currentThread().id}",
                     "span.type": "fakeType",
                     "resource.name": "fakeResource"],
+      "annotations": [["timestamp" : 1000, "value": "{\"event\":\"some event\"}"]],
       "name"     : "fakeOperation",
       "kind": null,
       "localEndpoint": ["serviceName": "my-service"],
@@ -97,12 +98,13 @@ class ZipkinV2ApiTest extends Specification {
                     "thread.id": "${Thread.currentThread().id}",
                     "span.type": "fakeType",
                     "resource.name": "my-resource"],
+      "annotations": [],
       "name"     : "fakeOperation",
       "localEndpoint": ["serviceName": "fakeService"],
       "kind"    : null,
       "timestamp"    : 100,
     ])]
-    [[SpanFactory.newSpanOf(100L).setTag("span.kind", "CliEnt")]] | [new TreeMap<>([
+    [[SpanFactory.newSpanOf(100L).setTag("span.kind", "CliEnt").log(1000L, "some event").log(2000L, Collections.singletonMap("another event", 1))]] | [new TreeMap<>([
       "traceId" : "0000000000000001",
       "id"  :     "0000000000000001",
       "parentId": "0000000000000000",
@@ -111,6 +113,7 @@ class ZipkinV2ApiTest extends Specification {
                     "thread.id": "${Thread.currentThread().id}",
                     "span.type": "fakeType",
                     "resource.name": "fakeResource"],
+      "annotations": [["timestamp" : 1000, "value": "{\"event\":\"some event\"}"], ["timestamp" : 2000, "value":"{\"another event\":1}"]],
       "name"     : "fakeOperation",
       "localEndpoint": ["serviceName": "fakeService"],
       "kind"    : "CliEnt",
@@ -125,6 +128,7 @@ class ZipkinV2ApiTest extends Specification {
                     "thread.id": "${Thread.currentThread().id}",
                     "span.type": "fakeType",
                     "resource.name": "fakeResource"],
+      "annotations": [],
       "name"     : "fakeResource",
       "localEndpoint": ["serviceName": "fakeService"],
       "kind"    : "SerVeR",


### PR DESCRIPTION
Currently `span.log()` is a noop unless a map with the OT error object field is provided, in which case the object is expanded as a set of error tags.  These changes introduce a general log mechanism and restrict the cases where the expanded error tagging is applied.  Not keeping the existing error tagging process warrants updating all instrumentation tests and is out of scope for this functionality.