### PR TITLE
Update resource name

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -61,7 +61,7 @@ class LagomTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET ws://?/echo"
+          resourceName "ws://?/echo"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -99,7 +99,7 @@ class LagomTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET ws://?/error"
+          resourceName "ws://?/error"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -79,7 +79,7 @@ class AkkaHttpClientInstrumentationTest extends AgentTestRunner {
           parent()
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET /$route"
+          resourceName "/$route"
           spanType DDSpanTypes.HTTP_CLIENT
           errored expectedError
           tags {
@@ -127,7 +127,7 @@ class AkkaHttpClientInstrumentationTest extends AgentTestRunner {
           parent()
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET /test"
+          resourceName "/test"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
           tags {
@@ -207,7 +207,7 @@ class AkkaHttpClientInstrumentationTest extends AgentTestRunner {
           parent()
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET /$route"
+          resourceName "/$route"
           spanType DDSpanTypes.HTTP_CLIENT
           errored expectedError
           tags {
@@ -257,7 +257,7 @@ class AkkaHttpClientInstrumentationTest extends AgentTestRunner {
           parent()
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET /test"
+          resourceName "/test"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
           tags {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -48,7 +48,7 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
           parentId "456"
           serviceName "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET /test"
+          resourceName "/test"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -89,7 +89,7 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET /$endpoint"
+          resourceName "/$endpoint"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {
@@ -128,7 +128,7 @@ class AkkaHttpServerInstrumentationTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "akka-http.request"
-          resourceName "GET /server-error"
+          resourceName "/server-error"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWSClientTest.groovy
@@ -149,7 +149,7 @@ class AWSClientTest extends AgentTestRunner {
         }
         span(1) {
           operationName "http.request"
-          resourceName "$method /$url"
+          resourceName "/$url"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
           childOf(span(0))
@@ -223,7 +223,7 @@ class AWSClientTest extends AgentTestRunner {
         }
         span(1) {
           operationName "http.request"
-          resourceName "$method /$url"
+          resourceName "/$url"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
           childOf(span(0))
@@ -337,7 +337,7 @@ class AWSClientTest extends AgentTestRunner {
         (1..4).each {
           span(it) {
             operationName "http.request"
-            resourceName "GET /someBucket/someKey"
+            resourceName "/someBucket/someKey"
             spanType DDSpanTypes.HTTP_CLIENT
             errored true
             childOf(span(0))

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWSClientTest.groovy
@@ -119,7 +119,7 @@ class AWSClientTest extends AgentTestRunner {
         }
         span(1) {
           operationName "http.request"
-          resourceName "$method /$url"
+          resourceName "/$url"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
           childOf(span(0))
@@ -193,7 +193,7 @@ class AWSClientTest extends AgentTestRunner {
         }
         span(1) {
           operationName "http.request"
-          resourceName "$method /$url"
+          resourceName "/$url"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
           childOf(span(0))
@@ -303,7 +303,7 @@ class AWSClientTest extends AgentTestRunner {
         (1..4).each {
           span(it) {
             operationName "http.request"
-            resourceName "GET /someBucket/someKey"
+            resourceName "/someBucket/someKey"
             spanType DDSpanTypes.HTTP_CLIENT
             errored true
             childOf(span(0))

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/AwsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/AwsClientTest.groovy
@@ -87,7 +87,7 @@ class AwsClientTest extends AgentTestRunner {
         }
         span(1) {
           operationName "http.request"
-          resourceName "$method $path"
+          resourceName "$path"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
           childOf(span(0))
@@ -180,7 +180,7 @@ class AwsClientTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           operationName "netty.client.request"
-          resourceName "$method $path"
+          resourceName "$path"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
           parent()
@@ -270,7 +270,7 @@ class AwsClientTest extends AgentTestRunner {
         (1..4).each {
           span(it) {
             operationName "http.request"
-            resourceName "GET /someBucket/someKey"
+            resourceName "/someBucket/someKey"
             spanType DDSpanTypes.HTTP_CLIENT
             errored true
             childOf(span(0))

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -81,7 +81,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           serviceName "elasticsearch"
-          resourceName "GET _cluster/health"
+          resourceName "_cluster/health"
           operationName "elasticsearch.rest.query"
           spanType DDSpanTypes.ELASTICSEARCH
           parent()
@@ -98,7 +98,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
         }
         span(1) {
           serviceName "elasticsearch"
-          resourceName "GET _cluster/health"
+          resourceName "_cluster/health"
           operationName "http.request"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -86,7 +86,7 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           serviceName "elasticsearch"
-          resourceName "GET _cluster/health"
+          resourceName "_cluster/health"
           operationName "elasticsearch.rest.query"
           spanType DDSpanTypes.ELASTICSEARCH
           parent()
@@ -103,7 +103,7 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
         }
         span(1) {
           serviceName "elasticsearch"
-          resourceName "GET _cluster/health"
+          resourceName "_cluster/health"
           operationName "http.request"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -85,7 +85,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           serviceName "elasticsearch"
-          resourceName "GET _cluster/health"
+          resourceName "_cluster/health"
           operationName "elasticsearch.rest.query"
           spanType DDSpanTypes.ELASTICSEARCH
           parent()
@@ -102,7 +102,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
         }
         span(1) {
           serviceName "elasticsearch"
-          resourceName "GET _cluster/health"
+          resourceName "_cluster/health"
           operationName "http.request"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -81,7 +81,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           serviceName "elasticsearch"
-          resourceName "GET _cluster/health"
+          resourceName "_cluster/health"
           operationName "elasticsearch.rest.query"
           spanType DDSpanTypes.ELASTICSEARCH
           parent()
@@ -98,7 +98,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
         }
         span(1) {
           serviceName "elasticsearch"
-          resourceName "GET _cluster/health"
+          resourceName "_cluster/health"
           operationName "http.request"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -74,7 +74,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
@@ -92,7 +92,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(2) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
@@ -157,7 +157,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
@@ -175,7 +175,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(2) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
@@ -224,7 +224,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "HEAD /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
@@ -273,7 +273,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
@@ -339,7 +339,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "POST /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false
@@ -407,7 +407,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(0) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored false
@@ -454,7 +454,7 @@ class HttpUrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "POST /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored false

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -42,7 +42,7 @@ class UrlConnectionTest extends AgentTestRunner {
         span(1) {
           serviceName renameService ? "localhost" : "unnamed-java-app"
           operationName OPERATION_NAME
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored true

--- a/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client/src/test/groovy/JaxRsClientTest.groovy
@@ -51,7 +51,7 @@ class JaxRsClientTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           serviceName "unnamed-java-app"
-          resourceName "GET /ping"
+          resourceName "/ping"
           operationName "jax-rs.client.call"
           spanType "http"
           parent()
@@ -102,7 +102,7 @@ class JaxRsClientTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           serviceName "unnamed-java-app"
-          resourceName "GET /ping"
+          resourceName "/ping"
           operationName "jax-rs.client.call"
           spanType "http"
           parent()

--- a/dd-java-agent/instrumentation/jersey/src/test/groovy/JerseyInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jersey/src/test/groovy/JerseyInstrumentationTest.groovy
@@ -46,7 +46,7 @@ class JerseyInstrumentationTest extends AgentTestRunner {
           parentId "456"
           serviceName "unnamed-java-app"
           operationName "jersey.request"
-          resourceName "POST /test/hello/bob"
+          resourceName "/test/hello/bob"
           errored false
           tags {
             defaultTags(true)
@@ -88,7 +88,7 @@ class JerseyInstrumentationTest extends AgentTestRunner {
           parentId "456"
           serviceName "unnamed-java-app"
           operationName "jersey.request"
-          resourceName "GET /test/blowup"
+          resourceName "/test/blowup"
           errored true
           tags {
             defaultTags(true)

--- a/dd-java-agent/instrumentation/jetty-6/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-6/src/test/groovy/JettyHandlerTest.groovy
@@ -54,7 +54,7 @@ class JettyHandlerTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "jetty.request"
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           parent()
@@ -102,7 +102,7 @@ class JettyHandlerTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "jetty.request"
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           parent()

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -55,7 +55,7 @@ class JettyHandlerTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "jetty.request"
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           parent()
@@ -114,7 +114,7 @@ class JettyHandlerTest extends AgentTestRunner {
           span(0) {
             serviceName "unnamed-java-app"
             operationName "jetty.request"
-            resourceName "GET /"
+            resourceName "/"
             spanType DDSpanTypes.HTTP_SERVER
           }
         }
@@ -152,7 +152,7 @@ class JettyHandlerTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "jetty.request"
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           parent()
@@ -177,7 +177,7 @@ class JettyHandlerTest extends AgentTestRunner {
           span(0) {
             serviceName "unnamed-java-app"
             operationName "jetty.request"
-            resourceName "GET /"
+            resourceName "/"
             spanType DDSpanTypes.HTTP_SERVER
             errored true
             parent()

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -89,7 +89,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "GET /$jspWebappContext/$jspFileName"
+          resourceName "/$jspWebappContext/$jspFileName"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -164,7 +164,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "GET /$jspWebappContext/getQuery.jsp"
+          resourceName "/$jspWebappContext/getQuery.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -236,7 +236,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "POST /$jspWebappContext/post.jsp"
+          resourceName "/$jspWebappContext/post.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -305,7 +305,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "GET /$jspWebappContext/$jspFileName"
+          resourceName "/$jspWebappContext/$jspFileName"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {
@@ -388,7 +388,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "GET /$jspWebappContext/includes/includeHtml.jsp"
+          resourceName "/$jspWebappContext/includes/includeHtml.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -456,7 +456,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "GET /$jspWebappContext/includes/includeMulti.jsp"
+          resourceName "/$jspWebappContext/includes/includeMulti.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -580,7 +580,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "GET /$jspWebappContext/$jspFileName"
+          resourceName "/$jspWebappContext/$jspFileName"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -88,7 +88,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "GET /$jspWebappContext/$forwardFromFileName"
+          resourceName "/$jspWebappContext/$forwardFromFileName"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -190,7 +190,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "GET /$jspWebappContext/forwards/forwardToHtml.jsp"
+          resourceName "/$jspWebappContext/forwards/forwardToHtml.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -258,7 +258,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "GET /$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
+          resourceName "/$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -413,7 +413,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "GET /$jspWebappContext/forwards/forwardToJspForward.jsp"
+          resourceName "/$jspWebappContext/forwards/forwardToJspForward.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -539,7 +539,7 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           parent()
           serviceName jspWebappContext
           operationName "servlet.request"
-          resourceName "GET /$jspWebappContext/forwards/forwardToCompileError.jsp"
+          resourceName "/$jspWebappContext/forwards/forwardToCompileError.jsp"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           tags {

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -53,7 +53,7 @@ class Netty40ClientTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "netty.client.request"
-          resourceName "GET /get"
+          resourceName "/get"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(1)
           errored false
@@ -146,7 +146,7 @@ class Netty40ClientTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "netty.client.request"
-          resourceName "POST /post"
+          resourceName "/post"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(1)
           errored error

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -63,7 +63,7 @@ class Netty40ServerTest extends AgentTestRunner {
           parentId "456"
           serviceName "unnamed-java-app"
           operationName "netty.request"
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -135,9 +135,9 @@ class Netty40ServerTest extends AgentTestRunner {
 
     where:
     responseCode                             | name    | error
-    HttpResponseStatus.OK                    | "GET /" | false
+    HttpResponseStatus.OK                    | "/" | false
     HttpResponseStatus.NOT_FOUND             | "404"   | false
-    HttpResponseStatus.INTERNAL_SERVER_ERROR | "GET /" | true
+    HttpResponseStatus.INTERNAL_SERVER_ERROR | "/" | true
   }
 
   def "test #responseCode statusCode rewrite #rewrite"() {

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -54,7 +54,7 @@ class Netty41ClientTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "netty.client.request"
-          resourceName "GET /get"
+          resourceName "/get"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(1)
           errored false
@@ -141,7 +141,7 @@ class Netty41ClientTest extends AgentTestRunner {
         span(0) {
           serviceName "unnamed-java-app"
           operationName "netty.client.request"
-          resourceName "POST /post"
+          resourceName "/post"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(1)
           errored error

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
@@ -63,7 +63,7 @@ class Netty41ServerTest extends AgentTestRunner {
           parentId "456"
           serviceName "unnamed-java-app"
           operationName "netty.request"
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -135,9 +135,9 @@ class Netty41ServerTest extends AgentTestRunner {
 
     where:
     responseCode                             | name    | error
-    HttpResponseStatus.OK                    | "GET /" | false
+    HttpResponseStatus.OK                    | "/"     | false
     HttpResponseStatus.NOT_FOUND             | "404"   | false
-    HttpResponseStatus.INTERNAL_SERVER_ERROR | "GET /" | true
+    HttpResponseStatus.INTERNAL_SERVER_ERROR | "/"     | true
   }
 
   def "test #responseCode statusCode rewrite #rewrite"() {

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -88,7 +88,7 @@ class OkHttp3Test extends AgentTestRunner {
           span(1) {
             operationName "okhttp.http"
             serviceName renameService ? "localhost" : "okhttp"
-            resourceName "GET /ping"
+            resourceName "/ping"
             spanType DDSpanTypes.HTTP_CLIENT
             errored false
             childOf(span(0))

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/latestDepTest/groovy/RatpackTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/latestDepTest/groovy/RatpackTest.groovy
@@ -54,7 +54,7 @@ class RatpackTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -73,7 +73,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -120,7 +120,7 @@ class RatpackTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          resourceName "GET /:foo/:bar?/baz"
+          resourceName "/:foo/:bar?/baz"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -139,7 +139,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /:foo/:bar?/baz"
+          resourceName "/:foo/:bar?/baz"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -181,7 +181,7 @@ class RatpackTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -201,7 +201,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -248,7 +248,7 @@ class RatpackTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -268,7 +268,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -313,7 +313,7 @@ class RatpackTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -333,7 +333,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -410,7 +410,7 @@ class RatpackTest extends AgentTestRunner {
       trace(2, 4) {
         // main app span that processed the request from OKHTTP request
         span(0) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -429,7 +429,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -448,7 +448,7 @@ class RatpackTest extends AgentTestRunner {
         }
         // Second http client call that receives the 'ess' of Success
         span(2) {
-          resourceName "GET /?"
+          resourceName "/?"
           serviceName "unnamed-java-app"
           operationName "netty.client.request"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -468,7 +468,7 @@ class RatpackTest extends AgentTestRunner {
         }
         // First http client call that receives the 'Succ' of Success
         span(3) {
-          resourceName "GET /nested"
+          resourceName "/nested"
           serviceName "unnamed-java-app"
           operationName "netty.client.request"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -519,7 +519,7 @@ class RatpackTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -539,7 +539,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -625,7 +625,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(startSpanInHandler ? 1 : 0) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -644,7 +644,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(startSpanInHandler ? 2 : 1) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/main/java8/datadog/trace/instrumentation/ratpack/RatpackServerDecorator.java
@@ -74,8 +74,7 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
       description = "/" + description;
     }
 
-    final String resourceName = ctx.getRequest().getMethod().getName() + " " + description;
-    span.setTag(DDTags.RESOURCE_NAME, resourceName);
+    span.setTag(DDTags.RESOURCE_NAME, description);
 
     return span;
   }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackTest.groovy
@@ -81,7 +81,7 @@ class RatpackTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          resourceName "GET /$route"
+          resourceName "/$route"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -100,7 +100,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /$route"
+          resourceName "/$route"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -158,7 +158,7 @@ class RatpackTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          resourceName "GET /handler-error"
+          resourceName "/handler-error"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -178,7 +178,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /handler-error"
+          resourceName "/handler-error"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -225,7 +225,7 @@ class RatpackTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          resourceName "GET /promise-error"
+          resourceName "/promise-error"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -245,7 +245,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /promise-error"
+          resourceName "/promise-error"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -290,7 +290,7 @@ class RatpackTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -310,7 +310,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -387,7 +387,7 @@ class RatpackTest extends AgentTestRunner {
       trace(2, 4) {
         // main app span that processed the request from OKHTTP request
         span(0) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -406,7 +406,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -425,7 +425,7 @@ class RatpackTest extends AgentTestRunner {
         }
         // Second http client call that receives the 'ess' of Success
         span(2) {
-          resourceName "GET /?"
+          resourceName "/?"
           serviceName "unnamed-java-app"
           operationName "netty.client.request"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -445,7 +445,7 @@ class RatpackTest extends AgentTestRunner {
         }
         // First http client call that receives the 'Succ' of Success
         span(3) {
-          resourceName "GET /nested"
+          resourceName "/nested"
           serviceName "unnamed-java-app"
           operationName "netty.client.request"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -496,7 +496,7 @@ class RatpackTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -516,7 +516,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(1) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER
@@ -602,7 +602,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(startSpanInHandler ? 1 : 0) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "netty.request"
           spanType DDSpanTypes.HTTP_SERVER
@@ -621,7 +621,7 @@ class RatpackTest extends AgentTestRunner {
           }
         }
         span(startSpanInHandler ? 2 : 1) {
-          resourceName "GET /"
+          resourceName "/"
           serviceName "unnamed-java-app"
           operationName "ratpack.handler"
           spanType DDSpanTypes.HTTP_SERVER

--- a/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-2/src/test/groovy/JettyServlet2Test.groovy
@@ -84,7 +84,7 @@ class JettyServlet2Test extends AgentTestRunner {
           }
           serviceName "ctx"
           operationName "servlet.request"
-          resourceName "GET /ctx/$path"
+          resourceName "/ctx/$path"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -129,7 +129,7 @@ class JettyServlet2Test extends AgentTestRunner {
         span(0) {
           serviceName "ctx"
           operationName "servlet.request"
-          resourceName "GET /ctx/$path"
+          resourceName "/ctx/$path"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           parent()
@@ -171,7 +171,7 @@ class JettyServlet2Test extends AgentTestRunner {
         span(0) {
           serviceName "ctx"
           operationName "servlet.request"
-          resourceName "GET /ctx/$path"
+          resourceName "/ctx/$path"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           parent()

--- a/dd-java-agent/instrumentation/servlet-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -82,7 +82,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
           }
           serviceName context
           operationName "servlet.request"
-          resourceName "GET /$context/$path"
+          resourceName "/$context/$path"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -150,7 +150,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
             }
             serviceName context
             operationName "servlet.request"
-            resourceName "GET /$context/dispatch/$path"
+            resourceName "/$context/dispatch/$path"
             spanType DDSpanTypes.HTTP_SERVER
             errored false
             tags {
@@ -175,7 +175,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
         span(0) {
           serviceName context
           operationName "servlet.request"
-          resourceName "GET /$context/$path"
+          resourceName "/$context/$path"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           childOf TEST_WRITER[depth + 1][0]
@@ -210,7 +210,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
           }
           serviceName context
           operationName "servlet.request"
-          resourceName "GET /$context/dispatch/$path"
+          resourceName "/$context/dispatch/$path"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -270,7 +270,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
           }
           serviceName context
           operationName "servlet.request"
-          resourceName "GET /$context/dispatch/$path"
+          resourceName "/$context/dispatch/$path"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -293,7 +293,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
         span(0) {
           serviceName context
           operationName "servlet.request"
-          resourceName "GET /$context/$path"
+          resourceName "/$context/$path"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           childOf TEST_WRITER[0][0]
@@ -342,7 +342,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
           trace(i, 1) {
             span(0) {
               operationName "servlet.request"
-              resourceName "GET /$context/dispatch/async"
+              resourceName "/$context/dispatch/async"
               spanType DDSpanTypes.HTTP_SERVER
               parent()
             }
@@ -351,7 +351,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
         trace(dispatched ? i + 1 : i, 1) {
           span(0) {
             operationName "servlet.request"
-            resourceName "GET /$context/async"
+            resourceName "/$context/async"
             spanType DDSpanTypes.HTTP_SERVER
             if (dispatched) {
               childOf TEST_WRITER[i][0]
@@ -385,7 +385,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
         span(0) {
           serviceName context
           operationName "servlet.request"
-          resourceName "GET /$context/$path"
+          resourceName "/$context/$path"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           parent()
@@ -431,7 +431,7 @@ abstract class AbstractServlet3Test<CONTEXT> extends AgentTestRunner {
         span(0) {
           serviceName context
           operationName "servlet.request"
-          resourceName "GET /$context/$path"
+          resourceName "/$context/$path"
           spanType DDSpanTypes.HTTP_SERVER
           errored true
           parent()

--- a/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring-web/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -72,9 +72,8 @@ public class SpringWebHttpServerDecorator
       final String method = request.getMethod();
       final Object bestMatchingPattern =
           request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
-      if (method != null && bestMatchingPattern != null) {
-        final String resourceName = method + " " + bestMatchingPattern;
-        span.setTag(DDTags.RESOURCE_NAME, resourceName);
+      if (bestMatchingPattern != null) {
+        span.setTag(DDTags.RESOURCE_NAME, bestMatchingPattern.toString());
         span.setTag(DDTags.SPAN_TYPE, DDSpanTypes.HTTP_SERVER);
       }
     }

--- a/dd-java-agent/instrumentation/spring-web/src/v40Test/groovy/test/RestTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/spring-web/src/v40Test/groovy/test/RestTemplateTest.groovy
@@ -74,7 +74,7 @@ class RestTemplateTest extends AgentTestRunner {
         span(1) {
           operationName "http.request"
           serviceName "rest-template"
-          resourceName "GET /ping"
+          resourceName "/ping"
           errored false
           childOf(span(0))
           spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/spring-web/src/v40Test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-web/src/v40Test/groovy/test/SpringBootBasedTest.groovy
@@ -38,7 +38,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_SERVER
           childOf trace(1).get(0)
           errored false
@@ -61,7 +61,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           operationName "http.request"
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored false
@@ -96,7 +96,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName(status.value == 404 ? "404" : "GET /param/{parameter}/")
+          resourceName(status.value == 404 ? "404" : "/param/{parameter}/")
           spanType DDSpanTypes.HTTP_SERVER
           childOf trace(1).get(0)
           errored false
@@ -120,7 +120,7 @@ class SpringBootBasedTest extends AgentTestRunner {
         span(0) {
           operationName "http.request"
           if (status == HttpStatus.OK) {
-            resourceName("GET /param/?/")
+            resourceName("/param/?/")
           } else {
             resourceName("404")
           }
@@ -160,7 +160,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "GET /error"
+          resourceName "/error"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored false
@@ -182,7 +182,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           operationName "servlet.request"
-          resourceName "GET /param/?/"
+          resourceName "/param/?/"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored false
@@ -203,7 +203,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(2, 1) {
         span(0) {
           operationName "http.request"
-          resourceName "GET /param/?/"
+          resourceName "/param/?/"
           spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored false
@@ -316,7 +316,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "GET /error/{parameter}/"
+          resourceName "/error/{parameter}/"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored true
@@ -340,7 +340,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(1, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "GET /error"
+          resourceName "/error"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored true
@@ -363,7 +363,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(2, 1) {
         span(0) {
           operationName "http.request"
-          resourceName "GET /error/qwerty/"
+          resourceName "/error/qwerty/"
           spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored true
@@ -393,7 +393,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "POST /validated"
+          resourceName "/validated"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(1).get(0))
           errored false
@@ -416,7 +416,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           operationName "http.request"
-          resourceName "POST /validated"
+          resourceName "/validated"
           spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored false
@@ -451,7 +451,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "POST /validated"
+          resourceName "/validated"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored false
@@ -478,7 +478,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(1, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "POST /error"
+          resourceName "/error"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored false
@@ -500,7 +500,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(2, 1) {
         span(0) {
           operationName "http.request"
-          resourceName "POST /validated"
+          resourceName "/validated"
           spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored false

--- a/dd-java-agent/instrumentation/spring-web/src/v50Test/groovy/test/RestTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/spring-web/src/v50Test/groovy/test/RestTemplateTest.groovy
@@ -75,7 +75,7 @@ class RestTemplateTest extends AgentTestRunner {
         span(1) {
           operationName "http.request"
           serviceName  "rest-template"
-          resourceName "GET /ping"
+          resourceName "/ping"
           errored false
           childOf(span(0))
           spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/spring-web/src/v50Test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-web/src/v50Test/groovy/test/SpringBootBasedTest.groovy
@@ -38,7 +38,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_SERVER
           childOf trace(1).get(0)
           errored false
@@ -61,7 +61,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           operationName "http.request"
-          resourceName "GET /"
+          resourceName "/"
           spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored false
@@ -96,7 +96,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName(status.value == 404 ? "404" : "GET /param/{parameter}/")
+          resourceName(status.value == 404 ? "404" : "/param/{parameter}/")
           spanType DDSpanTypes.HTTP_SERVER
           childOf trace(1).get(0)
           errored false
@@ -120,7 +120,7 @@ class SpringBootBasedTest extends AgentTestRunner {
         span(0) {
           operationName "http.request"
           if (status == HttpStatus.OK) {
-            resourceName("GET /param/?/")
+            resourceName("/param/?/")
           } else {
             resourceName("404")
           }
@@ -160,7 +160,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "GET /error"
+          resourceName "/error"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored false
@@ -182,7 +182,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           operationName "servlet.request"
-          resourceName "GET /param/?/"
+          resourceName "/param/?/"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored false
@@ -203,7 +203,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(2, 1) {
         span(0) {
           operationName "http.request"
-          resourceName "GET /param/?/"
+          resourceName "/param/?/"
           spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored false
@@ -316,7 +316,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "GET /error/{parameter}/"
+          resourceName "/error/{parameter}/"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored true
@@ -340,7 +340,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(1, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "GET /error"
+          resourceName "/error"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored true
@@ -364,7 +364,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(2, 1) {
         span(0) {
           operationName "http.request"
-          resourceName "GET /error/qwerty/"
+          resourceName "/error/qwerty/"
           spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored true
@@ -394,7 +394,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "POST /validated"
+          resourceName "/validated"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(1).get(0))
           errored false
@@ -417,7 +417,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           operationName "http.request"
-          resourceName "POST /validated"
+          resourceName "/validated"
           spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored false
@@ -451,7 +451,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "POST /validated"
+          resourceName "/validated"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored false
@@ -478,7 +478,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(1, 2) {
         span(0) {
           operationName "servlet.request"
-          resourceName "POST /error"
+          resourceName "/error"
           spanType DDSpanTypes.HTTP_SERVER
           childOf(trace(2).get(0))
           errored false
@@ -501,7 +501,7 @@ class SpringBootBasedTest extends AgentTestRunner {
       trace(2, 1) {
         span(0) {
           operationName "http.request"
-          resourceName "POST /validated"
+          resourceName "/validated"
           spanType DDSpanTypes.HTTP_CLIENT
           parent()
           errored false

--- a/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
+++ b/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
@@ -285,7 +285,7 @@ class TwilioClientTest extends AgentTestRunner {
         span(2) {
           serviceName "twilio-sdk"
           operationName "http.request"
-          resourceName "POST /?/Accounts/abc/Messages.json"
+          resourceName "/?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
         }
@@ -384,14 +384,14 @@ class TwilioClientTest extends AgentTestRunner {
         span(2) {
           serviceName "twilio-sdk"
           operationName "http.request"
-          resourceName "POST /?/Accounts/abc/Messages.json"
+          resourceName "/?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
         }
         span(3) {
           serviceName "twilio-sdk"
           operationName "http.request"
-          resourceName "POST /?/Accounts/abc/Messages.json"
+          resourceName "/?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
         }
@@ -516,14 +516,14 @@ class TwilioClientTest extends AgentTestRunner {
         span(3) {
           serviceName "twilio-sdk"
           operationName "http.request"
-          resourceName "POST /?/Accounts/abc/Messages.json"
+          resourceName "/?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored false
         }
         span(4) {
           serviceName "twilio-sdk"
           operationName "http.request"
-          resourceName "POST /?/Accounts/abc/Messages.json"
+          resourceName "/?/Accounts/abc/Messages.json"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
         }

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxHttpClientTest.groovy
@@ -72,7 +72,7 @@ class VertxHttpClientTest extends AgentTestRunner {
           parent()
           serviceName "unnamed-java-app"
           operationName "netty.client.request"
-          resourceName "GET /$route"
+          resourceName "/$route"
           spanType DDSpanTypes.HTTP_CLIENT
           errored expectedError
           tags {

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/VertxServerTest.groovy
@@ -51,7 +51,7 @@ class VertxServerTest extends AgentTestRunner {
           parentId "456"
           serviceName "unnamed-java-app"
           operationName "netty.request"
-          resourceName "GET /test"
+          resourceName "/test"
           spanType DDSpanTypes.HTTP_SERVER
           errored false
           tags {
@@ -111,8 +111,8 @@ class VertxServerTest extends AgentTestRunner {
 
     where:
     responseCode                             | name         | path          | error
-    HttpResponseStatus.OK                    | "GET /"      | ""            | false
+    HttpResponseStatus.OK                    | "/"          | ""            | false
     HttpResponseStatus.NOT_FOUND             | "404"        | "doesnt-exit" | false
-    HttpResponseStatus.INTERNAL_SERVER_ERROR | "GET /error" | "error"       | true
+    HttpResponseStatus.INTERNAL_SERVER_ERROR | "/error"     | "error"       | true
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -290,7 +290,7 @@ abstract class HttpClientTest<T extends HttpClientDecorator> extends AgentTestRu
       }
       serviceName renameService ? "localhost" : "unnamed-java-app"
       operationName "http.request"
-      resourceName "GET $uri.path"
+      resourceName "$uri.path"
       spanType DDSpanTypes.HTTP_CLIENT
       errored exception != null
       tags {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java
@@ -42,12 +42,6 @@ public class URLAsResourceName extends AbstractDecorator {
     // normalize the path
     path = norm(path);
 
-    // if the verb (GET, POST ...) is present, add it
-    final String verb = (String) context.getTags().get(Tags.HTTP_METHOD.getKey());
-    if (verb != null && !verb.isEmpty()) {
-      path = verb + " " + path;
-    }
-
     context.setResourceName(path);
     return true;
   }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
@@ -114,6 +114,6 @@ class URLAsResourceNameTest extends Specification {
     "/path"                     | "/path"             | [:]
     "/ABC/a-1/b_2/c.3/d4d/5f/6" | "/ABC/?/?/?/?/?/?"  | [:]
     "/not-found"                | "fakeResource"      | [(Tags.HTTP_STATUS.key): 404]
-    "/with-method"              | "Post /with-method" | [(Tags.HTTP_METHOD.key): "Post"]
+    "/with-method"              | "/with-method"      | [(Tags.HTTP_METHOD.key): "Post"]
   }
 }


### PR DESCRIPTION
Not sure this catches every case of the method name being used in the resource name, but at least it gets everything affected by the `URLAsResourceName` decorator.