### PR TITLE
Don't trace Zipkin writer submissions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
 
     - run:
         name: Build Project
-        command: GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1G -Xms64M' -Ddatadog.forkedMaxHeapSize=1G -Ddatadog.forkedMinHeapSize=64M" ./gradlew clean :dd-java-agent:shadowJar compileTestGroovy compileLatestDepTestGroovy compileTestScala compileLatestDepTestScala compileTestJava compileLatestDepTestJava --build-cache --parallel --stacktrace --no-daemon --max-workers=8
+        command: GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1G -Xms64M' -Ddatadog.forkedMaxHeapSize=1G -Ddatadog.forkedMinHeapSize=64M" ./gradlew clean :dd-java-agent:shadowJar --build-cache --stacktrace --no-daemon
 
     - run:
         name: Collect Libs
@@ -67,7 +67,7 @@ jobs:
 
     - run:
         name: Run Tests
-        command: GRADLE_OPTS="-Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M" ./gradlew $TEST_TASK --build-cache --parallel --stacktrace --no-daemon --max-workers=6
+        command: GRADLE_OPTS="-Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M" ./gradlew $TEST_TASK --build-cache --stacktrace --no-daemon
 
     - run:
         name: Collect Reports
@@ -136,7 +136,7 @@ jobs:
 
     - run:
         name: Run Trace Agent Tests
-        command: ./gradlew traceAgentTest --build-cache --parallel --stacktrace --no-daemon --max-workers=8
+        command: ./gradlew traceAgentTest --build-cache --stacktrace --no-daemon
 
     - run:
         name: Collect Reports
@@ -168,7 +168,7 @@ jobs:
 
     - run:
         name: Build Project
-        command: GRADLE_OPTS="-Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M" ./gradlew check -PskipTests --build-cache --parallel --stacktrace --no-daemon --max-workers=8
+        command: GRADLE_OPTS="-Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M" ./gradlew check -PskipTests --build-cache --stacktrace --no-daemon
 
     - run:
         name: Collect Reports
@@ -193,7 +193,7 @@ jobs:
         # Note: we do not have `--max-workers` here to have number of workers (threads) equal to number of CPUs (32 currently).
         # This should speed things up slightly because muzzle may do a lot of IO bound work: reading off disk and downloading
         # dependencies.
-        command: SKIP_BUILDSCAN="true" GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx4G -Xms64M' -Ddatadog.forkedMaxHeapSize=4G -Ddatadog.forkedMinHeapSize=64M" ./gradlew muzzle --parallel --stacktrace --no-daemon
+        command: SKIP_BUILDSCAN="true" GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms64M' -Ddatadog.forkedMaxHeapSize=2G -Ddatadog.forkedMinHeapSize=64M" ./gradlew muzzle --parallel --stacktrace --no-daemon
 
     - save_cache:
         key: signalfx-java-tracing-version-scan-{{ checksum "signalfx-java-tracing.gradle" }}

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
@@ -2,9 +2,11 @@ package datadog.trace.instrumentation.okhttp3;
 
 import static datadog.trace.instrumentation.okhttp3.OkHttpClientDecorator.DECORATE;
 
+import datadog.trace.api.Config;
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
 import java.io.IOException;
+import java.net.URI;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Interceptor;
 import okhttp3.Request;
@@ -16,6 +18,13 @@ public class TracingInterceptor implements Interceptor {
   @Override
   public Response intercept(final Chain chain) throws IOException {
     if (chain.request().header("Datadog-Meta-Lang") != null) {
+      return chain.proceed(chain.request());
+    }
+
+    // Don't trace trace submissions
+    URI uri = chain.request().url().uri();
+    if (uri.getPath().equals(Config.get().getAgentPath())
+        && uri.getHost().equals(Config.get().getAgentHost())) {
       return chain.proceed(chain.request());
     }
 

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
@@ -50,13 +50,10 @@ public class ZipkinV2Api implements Api {
     final List<byte[]> serializedTraces = new ArrayList<>(traces.size());
     int sizeInBytes = 0;
     for (final List<DDSpan> trace : traces) {
-      System.out.println("ZipkinV2Api.sendTraces: " + trace.toString());
       try {
         final byte[] serializedTrace = serializeTrace(trace);
-        System.out.println("ZipkinV2Api.sendTraces: " + new String(serializedTrace));
         sizeInBytes += serializedTrace.length;
         serializedTraces.add(serializedTrace);
-        System.out.println("ZipkinV2Api.sendTraces: " + serializedTraces.toString());
       } catch (final JsonProcessingException e) {
         log.warn("Error serializing trace", e);
       }


### PR DESCRIPTION
Upstream feature additions have added undesired tracing of zipkin span reporting.  These changes filter out these requests and remove some cruft on my part.