### PR TITLE
Modify default client error range

### DIFF
--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/HttpClientDecoratorTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package datadog.trace.agent.decorator
 
 import datadog.trace.api.Config
@@ -94,9 +95,9 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     status | error | errorRange | resp
     200    | false | null       | [status: 200]
     399    | false | null       | [status: 399]
-    400    | true  | null       | [status: 400]
-    499    | true  | null       | [status: 499]
-    500    | false | null       | [status: 500]
+    400    | false  | null       | [status: 400]
+    499    | false  | null       | [status: 499]
+    500    | true | null       | [status: 500]
     500    | true  | "500"      | [status: 500]
     500    | true  | "400-500"  | [status: 500]
     600    | false | null       | [status: 600]

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -117,7 +117,7 @@ public class Config {
   private static final Set<Integer> DEFAULT_HTTP_SERVER_ERROR_STATUSES =
       parseIntegerRangeSet("500-599", "default");
   private static final Set<Integer> DEFAULT_HTTP_CLIENT_ERROR_STATUSES =
-      parseIntegerRangeSet("400-499", "default");
+      parseIntegerRangeSet("500-599", "default");
   private static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
   private static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   private static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.B3.name();

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -92,7 +92,7 @@ class ConfigTest extends Specification {
                              (TRACING_VERSION_KEY):TRACING_VERSION_VALUE]
     config.headerTags == [:]
     config.httpServerErrorStatuses == (500..599).toSet()
-    config.httpClientErrorStatuses == (400..499).toSet()
+    config.httpClientErrorStatuses == (500..599).toSet()
     config.httpClientSplitByDomain == false
     config.partialFlushMinSpans == 1000
     config.reportHostName == false
@@ -342,7 +342,7 @@ class ConfigTest extends Specification {
     config.mergedSpanTags == [(TRACING_LIBRARY_KEY):TRACING_LIBRARY_VALUE, (TRACING_VERSION_KEY):TRACING_VERSION_VALUE]
     config.headerTags == [:]
     config.httpServerErrorStatuses == (500..599).toSet()
-    config.httpClientErrorStatuses == (400..499).toSet()
+    config.httpClientErrorStatuses == (500..599).toSet()
     config.httpClientSplitByDomain == false
     config.propagationStylesToExtract.toList() == [Config.PropagationStyle.B3]
     config.propagationStylesToInject.toList() == [Config.PropagationStyle.B3]


### PR DESCRIPTION
µAPM considers 5xx errors, so we need to prevent clients from setting the error tag based on 4xx status codes by default.