### PR TITLE
Remove default runtime.id and language tags

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -43,14 +43,8 @@ class TagsAssert {
     assert tags["thread.name"] != null
     assert tags[Config.TRACING_LIBRARY_KEY] == Config.TRACING_LIBRARY_VALUE
     assert tags[Config.TRACING_VERSION_KEY] == Config.TRACING_VERSION_VALUE
-
-    if ("0" == spanParentId || distributedRootSpan) {
-      assert tags[Config.RUNTIME_ID_TAG] == Config.get().runtimeId
-      assert tags[Config.LANGUAGE_TAG_KEY] == Config.LANGUAGE_TAG_VALUE
-    } else {
-      assert tags[Config.RUNTIME_ID_TAG] == null
-      assert tags[Config.LANGUAGE_TAG_KEY] == null
-    }
+    assert tags[Config.RUNTIME_ID_TAG] == null
+    assert tags[Config.LANGUAGE_TAG_KEY] == null
   }
 
   def errorTags(Class<Throwable> errorType) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -433,9 +433,9 @@ public class Config {
    * @return A map of tag-name -> tag-value
    */
   private Map<String, String> getRuntimeTags() {
-    final Map<String, String> result = newHashMap(2);
-    result.put(RUNTIME_ID_TAG, runtimeId);
-    result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
+    // Rather than attempt to strip these on Zipkin encoding, do not use any
+    // undesired runtime tags to prevent collisions
+    final Map<String, String> result = newHashMap(0);
     return Collections.unmodifiableMap(result);
   }
 

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -24,8 +24,6 @@ import static datadog.trace.api.Config.JMX_FETCH_REFRESH_BEANS_PERIOD
 import static datadog.trace.api.Config.JMX_FETCH_STATSD_HOST
 import static datadog.trace.api.Config.JMX_FETCH_STATSD_PORT
 import static datadog.trace.api.Config.JMX_TAGS
-import static datadog.trace.api.Config.LANGUAGE_TAG_KEY
-import static datadog.trace.api.Config.LANGUAGE_TAG_VALUE
 import static datadog.trace.api.Config.TRACING_LIBRARY_KEY
 import static datadog.trace.api.Config.TRACING_LIBRARY_VALUE
 import static datadog.trace.api.Config.TRACING_VERSION_KEY
@@ -36,7 +34,6 @@ import static datadog.trace.api.Config.PRIORITY_SAMPLING
 import static datadog.trace.api.Config.PROPAGATION_STYLE_EXTRACT
 import static datadog.trace.api.Config.PROPAGATION_STYLE_INJECT
 import static datadog.trace.api.Config.RUNTIME_CONTEXT_FIELD_INJECTION
-import static datadog.trace.api.Config.RUNTIME_ID_TAG
 import static datadog.trace.api.Config.SERVICE
 import static datadog.trace.api.Config.SERVICE_MAPPING
 import static datadog.trace.api.Config.SERVICE_NAME
@@ -87,8 +84,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
     config.mergedSpanTags == [(TRACING_LIBRARY_KEY):TRACING_LIBRARY_VALUE, (TRACING_VERSION_KEY):TRACING_VERSION_VALUE]
-    config.mergedJmxTags == [(RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName,
-                             (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE, (TRACING_LIBRARY_KEY):TRACING_LIBRARY_VALUE,
+    config.mergedJmxTags == [(SERVICE): config.serviceName, (TRACING_LIBRARY_KEY):TRACING_LIBRARY_VALUE,
                              (TRACING_VERSION_KEY):TRACING_VERSION_VALUE]
     config.headerTags == [:]
     config.httpServerErrorStatuses == (500..599).toSet()
@@ -161,7 +157,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
+    config.mergedJmxTags == [b: "2", d: "4", (SERVICE): config.serviceName]
     config.headerTags == [e: "5"]
     config.httpServerErrorStatuses == (122..457).toSet()
     config.httpClientErrorStatuses == (111..111).toSet()
@@ -230,7 +226,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
+    config.mergedJmxTags == [b: "2", d: "4", (SERVICE): config.serviceName]
     config.headerTags == [e: "5"]
     config.httpServerErrorStatuses == (122..457).toSet()
     config.httpClientErrorStatuses == (111..111).toSet()
@@ -432,7 +428,7 @@ class ConfigTest extends Specification {
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
-    config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
+    config.mergedJmxTags == [b: "2", d: "4", (SERVICE): config.serviceName]
     config.headerTags == [e: "5"]
     config.httpServerErrorStatuses == (122..457).toSet()
     config.httpClientErrorStatuses == (111..111).toSet()

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDSpanBuilderTest.groovy
@@ -58,8 +58,6 @@ class DDSpanBuilderTest extends Specification {
     span.getTags() == [
       (DDTags.THREAD_NAME)     : Thread.currentThread().getName(),
       (DDTags.THREAD_ID)       : Thread.currentThread().getId(),
-      (Config.RUNTIME_ID_TAG)  : config.getRuntimeId(),
-      (Config.LANGUAGE_TAG_KEY): Config.LANGUAGE_TAG_VALUE,
       (Config.TRACING_LIBRARY_KEY): Config.TRACING_LIBRARY_VALUE,
       (Config.TRACING_VERSION_KEY): Config.TRACING_VERSION_VALUE
     ]
@@ -398,9 +396,7 @@ class DDSpanBuilderTest extends Specification {
     span.samplingPriority == extractedContext.samplingPriority
     span.context().origin == extractedContext.origin
     span.context().baggageItems == extractedContext.baggage
-    span.context().@tags == extractedContext.tags + [(Config.RUNTIME_ID_TAG)     : config.getRuntimeId(),
-                                                     (Config.LANGUAGE_TAG_KEY)   : Config.LANGUAGE_TAG_VALUE,
-                                                     (DDTags.THREAD_NAME)        : thread.name, (DDTags.THREAD_ID): thread.id,
+    span.context().@tags == extractedContext.tags + [(DDTags.THREAD_NAME)        : thread.name, (DDTags.THREAD_ID): thread.id,
                                                      (Config.TRACING_LIBRARY_KEY): Config.TRACING_LIBRARY_VALUE,
                                                      (Config.TRACING_VERSION_KEY): Config.TRACING_VERSION_VALUE]
 
@@ -421,9 +417,7 @@ class DDSpanBuilderTest extends Specification {
     span.samplingPriority == PrioritySampling.SAMPLER_KEEP // Since we're using the RateByServiceSampler
     span.context().origin == tagContext.origin
     span.context().baggageItems == [:]
-    span.context().@tags == tagContext.tags + [(Config.RUNTIME_ID_TAG)  : config.getRuntimeId(),
-                                               (Config.LANGUAGE_TAG_KEY): Config.LANGUAGE_TAG_VALUE,
-                                               (DDTags.THREAD_NAME)     : thread.name, (DDTags.THREAD_ID): thread.id,
+    span.context().@tags == tagContext.tags + [(DDTags.THREAD_NAME)        : thread.name, (DDTags.THREAD_ID): thread.id,
                                                (Config.TRACING_LIBRARY_KEY): Config.TRACING_LIBRARY_VALUE,
                                                (Config.TRACING_VERSION_KEY): Config.TRACING_VERSION_VALUE]
 
@@ -444,8 +438,6 @@ class DDSpanBuilderTest extends Specification {
     span.tags == tags + [
       (DDTags.THREAD_NAME)     : Thread.currentThread().getName(),
       (DDTags.THREAD_ID)       : Thread.currentThread().getId(),
-      (Config.RUNTIME_ID_TAG)  : config.getRuntimeId(),
-      (Config.LANGUAGE_TAG_KEY): Config.LANGUAGE_TAG_VALUE,
       (Config.TRACING_LIBRARY_KEY): Config.TRACING_LIBRARY_VALUE,
       (Config.TRACING_VERSION_KEY): Config.TRACING_VERSION_VALUE
     ]

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TraceInterceptorTest.groovy
@@ -142,12 +142,12 @@ class TraceInterceptorTest extends Specification {
 
     tags["thread.name"] != null
     tags["thread.id"] != null
-    tags["runtime-id"] != null
-    tags["language"] != null
+    tags["runtime-id"] == null
+    tags["language"] == null
 
     tags[Config.TRACING_LIBRARY_KEY] == Config.TRACING_LIBRARY_VALUE
     tags[Config.TRACING_VERSION_KEY] == Config.TRACING_VERSION_VALUE
-    tags.size() == 9
+    tags.size() == 7
   }
 
   def "register interceptor through bridge"() {

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -129,8 +129,8 @@ class DDTracerTest extends Specification {
     tracer.serviceName == DEFAULT_SERVICE_NAME
     tracer.sampler == sampler
     tracer.writer == writer
-    tracer.localRootSpanTags[Config.RUNTIME_ID_TAG].size() > 0 // not null or empty
-    tracer.localRootSpanTags[Config.LANGUAGE_TAG_KEY] == Config.LANGUAGE_TAG_VALUE
+    tracer.localRootSpanTags[Config.RUNTIME_ID_TAG] == null
+    tracer.localRootSpanTags[Config.LANGUAGE_TAG_KEY] == null
   }
 
   @Ignore


### PR DESCRIPTION
These tags aren't necessary or helpful for our traces.