### PR TITLE
Use ES action names for operations

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package datadog.trace.instrumentation.elasticsearch;
 
 import datadog.trace.agent.decorator.DatabaseClientDecorator;
@@ -46,8 +47,10 @@ public class ElasticsearchTransportClientDecorator extends DatabaseClientDecorat
 
   public Span onRequest(final Span span, final Class action, final Class request) {
     if (action != null) {
-      span.setTag(DDTags.RESOURCE_NAME, action.getSimpleName());
-      span.setTag("elasticsearch.action", action.getSimpleName());
+      String simpleName = action.getSimpleName();
+      span.setOperationName(simpleName);
+      span.setTag(DDTags.RESOURCE_NAME, simpleName);
+      span.setTag("elasticsearch.action", simpleName);
     }
     if (request != null) {
       span.setTag("elasticsearch.request", request.getSimpleName());

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
@@ -75,7 +76,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -103,7 +104,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -176,7 +177,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -193,7 +194,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -209,7 +210,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -229,7 +230,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -246,7 +247,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -264,7 +265,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
@@ -86,7 +87,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -117,7 +118,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -190,7 +191,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -210,7 +211,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -229,7 +230,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -252,7 +253,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -269,7 +270,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -290,7 +291,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package springdata
 
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
@@ -40,7 +41,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored false
           tags {
@@ -73,7 +74,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -90,7 +91,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -118,7 +119,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -149,7 +150,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -166,7 +167,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -186,7 +187,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -216,7 +217,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "DeleteAction"
-          operationName "elasticsearch.query"
+          operationName "DeleteAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -233,7 +234,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -253,7 +254,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package springdata
 
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
@@ -80,7 +81,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -144,7 +145,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -161,7 +162,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -177,7 +178,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -195,7 +196,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -212,7 +213,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -230,7 +231,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -250,7 +251,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -334,7 +335,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
@@ -75,7 +76,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -103,7 +104,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -176,7 +177,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -193,7 +194,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -209,7 +210,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -232,7 +233,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -249,7 +250,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -270,7 +271,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
@@ -86,7 +87,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -117,7 +118,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -190,7 +191,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -210,7 +211,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -229,7 +230,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -252,7 +253,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -269,7 +270,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -290,7 +291,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package springdata
 
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
@@ -40,7 +41,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored false
           tags {
@@ -73,7 +74,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -93,7 +94,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -121,7 +122,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -155,7 +156,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -175,7 +176,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -195,7 +196,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -228,7 +229,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "DeleteAction"
-          operationName "elasticsearch.query"
+          operationName "DeleteAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -248,7 +249,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -268,7 +269,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package springdata
 
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
@@ -80,7 +81,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -144,7 +145,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -161,7 +162,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -177,7 +178,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -195,7 +196,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -212,7 +213,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -233,7 +234,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -253,7 +254,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -334,7 +335,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
@@ -81,7 +82,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -109,7 +110,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -183,7 +184,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -200,7 +201,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -216,7 +217,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -236,7 +237,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -252,7 +253,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -275,7 +276,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
@@ -93,7 +94,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -124,7 +125,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -197,7 +198,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -217,7 +218,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -240,7 +241,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -256,7 +257,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -282,7 +283,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package springdata
 
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
@@ -40,7 +41,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored false
           tags {
@@ -73,7 +74,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -95,7 +96,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -123,7 +124,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -154,7 +155,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -176,7 +177,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -196,7 +197,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -226,7 +227,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "DeleteAction"
-          operationName "elasticsearch.query"
+          operationName "DeleteAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -247,7 +248,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -267,7 +268,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package springdata
 
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
@@ -100,7 +101,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -168,7 +169,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -185,7 +186,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -201,7 +202,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -219,7 +220,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -235,7 +236,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -258,7 +259,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName "RefreshAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -278,7 +279,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -362,7 +363,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName "SearchAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
@@ -81,7 +82,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -109,7 +110,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -183,7 +184,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -200,7 +201,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -216,7 +217,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -236,7 +237,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -252,7 +253,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -274,7 +275,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
@@ -93,7 +94,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -124,7 +125,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -197,7 +198,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -217,7 +218,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -240,7 +241,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -256,7 +257,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -281,7 +282,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
@@ -78,7 +79,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -106,7 +107,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -179,7 +180,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -196,7 +197,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -216,7 +217,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -232,7 +233,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -255,7 +256,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import com.anotherchrisberry.spock.extensions.retry.RetryOnFailure
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.PortUtils
@@ -90,7 +91,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName "ClusterHealthAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -121,7 +122,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -194,7 +195,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName "CreateIndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -214,7 +215,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -237,7 +238,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName "PutMappingAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -253,7 +254,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName "IndexAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"
@@ -279,7 +280,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
         span(0) {
           serviceName "elasticsearch"
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName "GetAction"
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT.key" "elasticsearch-java"


### PR DESCRIPTION
Provides more information than current `elasticsearch.query` as was initially done in v0.20.0 releases.