### PR TITLE
Version 0.28.0-sfx1

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -93,7 +93,7 @@ public class Config {
   public static final String TRACING_LIBRARY_KEY = "signalfx.tracing.library";
   public static final String TRACING_LIBRARY_VALUE = "java-tracing";
   public static final String TRACING_VERSION_KEY = "signalfx.tracing.version";
-  public static final String TRACING_VERSION_VALUE = "0.28.0-sfx0";
+  public static final String TRACING_VERSION_VALUE = "0.28.0-sfx1";
   public static final String DEFAULT_GLOBAL_TAGS =
       String.format(
           "%s:%s,%s:%s",

--- a/signalfx-java-tracing.gradle
+++ b/signalfx-java-tracing.gradle
@@ -16,7 +16,7 @@ def isCI = System.getenv("CI") != null
 
 allprojects {
   group = 'com.signalfx.public'
-  version = '0.28.0-sfx0'
+  version = '0.28.0-sfx1'
 
   if (isCI) {
     buildDir = "${rootDir}/workspace/${projectDir.path.replace(rootDir.path, '')}/build/"


### PR DESCRIPTION
* Align tag usage in database instrumentations with OpenTracing
* Add and document SIGNALFX_SPAN_TAGS configuration
* Add and document SIGNALFX_TRACING_ENABLED configuration
* Revert generalization of redis and elasticsearch operation names
* Add default ThreadPerTaskExecutor instrumentation for CompletableFuture
* Remove unnecessary/redundant tags
* Document compatibility with other JVM-based languages