### PR TITLE
Provide Kafka propagation toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ explicitly validated for compatibility with all instrumentations.
 | **Jetty Server** | 6.0.0+, 8.0.0+ | `jetty` | |
 | **JMS Messaging** | * | `jms` | |
 | **JSP** | 7+ | `jsp` | |
-| **Kafka Client** | 0.11.0.0+ | `kafka` | |
+| **Kafka Client** | 0.11.0.0+ | `kafka` | Disable trace propagation for unsupported environments with `-Dsignalfx.instrumentation.kafka.attempt-propagation=false` |
 | **Lettuce (Redis Client)** | 5.0.0+ | `lettuce` | |
 | _Java MDC_ | * | `-Dsignalfx.logs.injection=true` on Java invocation | Injects `signalfx.trace_id` and `signalfx.span_id` to MDC contexts |
 | **Memcached (SpyMemcached)** | 2.10.0+ | `spymemcached` | |

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/kafka-clients-0.11.gradle
@@ -1,3 +1,4 @@
+// Modified by Signalfx
 muzzle {
   pass {
     group = "org.apache.kafka"
@@ -13,6 +14,10 @@ apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {
   latestDepTest {
+    dirName = 'test'
+  }
+
+  propertyTest {
     dirName = 'test'
   }
 }
@@ -43,3 +48,8 @@ dependencies {
   latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '+'
   latestDepTestCompile group: 'org.assertj', name: 'assertj-core', version: '3.+'
 }
+
+tasks.getByName('propertyTest').configure {
+  jvmArgs "-Dsignalfx.instrumentation.kafka.attempt-propagation=false"
+}
+test.dependsOn(propertyTest)

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -9,6 +9,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
 import io.opentracing.Scope;
 import io.opentracing.propagation.Format;
 import io.opentracing.util.GlobalTracer;
@@ -75,7 +76,8 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
       // Do not inject headers for batch versions below 2
       // This is how similar check is being done in Kafka client itself:
       // https://github.com/apache/kafka/blob/05fcfde8f69b0349216553f711fdfc3f0259c601/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java#L411-L412
-      if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2) {
+      if (Config.get().isKafkaAttemptPropagation()
+          && apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2) {
         try {
           GlobalTracer.get()
               .inject(

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterable.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterable.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.kafka_clients;
 
+import datadog.trace.api.Config;
 import io.opentracing.Scope;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
@@ -65,9 +66,12 @@ public class TracingIterable implements Iterable<ConsumerRecord> {
 
       try {
         if (next != null) {
-          final SpanContext spanContext =
-              GlobalTracer.get()
-                  .extract(Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(next.headers()));
+          SpanContext spanContext = null;
+          if (Config.get().isKafkaAttemptPropagation()) {
+            spanContext =
+                GlobalTracer.get()
+                    .extract(Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(next.headers()));
+          }
           currentScope =
               GlobalTracer.get().buildSpan(operationName).asChildOf(spanContext).startActive(true);
           decorator.afterStart(currentScope);

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 muzzle {
   pass {
     group = "org.apache.kafka"
@@ -12,6 +13,10 @@ apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {
   latestDepTest {
+    dirName = 'test'
+  }
+
+  propertyTest {
     dirName = 'test'
   }
 }
@@ -48,3 +53,8 @@ dependencies {
   latestDepTestCompile group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '+'
   latestDepTestCompile group: 'org.assertj', name: 'assertj-core', version: '3.+'
 }
+
+tasks.getByName('propertyTest').configure {
+  jvmArgs "-Dsignalfx.instrumentation.kafka.attempt-propagation=false"
+}
+test.dependsOn(propertyTest)

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
@@ -11,6 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
 import io.opentracing.Scope;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
@@ -66,10 +67,13 @@ public class KafkaStreamsProcessorInstrumentation {
           return;
         }
 
-        final SpanContext extractedContext =
-            GlobalTracer.get()
-                .extract(
-                    Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(record.value.headers()));
+        SpanContext extractedContext = null;
+        if (Config.get().isKafkaAttemptPropagation()) {
+          extractedContext =
+              GlobalTracer.get()
+                  .extract(
+                      Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(record.value.headers()));
+        }
 
         final Scope scope =
             GlobalTracer.get()

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -74,6 +74,9 @@ public class Config {
   public static final String PROPAGATION_STYLE_EXTRACT = "propagation.style.extract";
   public static final String PROPAGATION_STYLE_INJECT = "propagation.style.inject";
 
+  public static final String KAFKA_ATTEMPT_PROPAGATION =
+      "instrumentation.kafka.attempt-propagation";
+
   public static final String JMX_FETCH_ENABLED = "jmxfetch.enabled";
   public static final String JMX_FETCH_METRICS_CONFIGS = "jmxfetch.metrics-configs";
   public static final String JMX_FETCH_CHECK_PERIOD = "jmxfetch.check-period";
@@ -125,6 +128,8 @@ public class Config {
   private static final String DEFAULT_PROPAGATION_STYLE_INJECT = PropagationStyle.B3.name();
   private static final boolean DEFAULT_JMX_FETCH_ENABLED = false;
 
+  public static final boolean DEFAULT_KAFKA_ATTEMPT_PROPAGATION = true;
+
   public static final int DEFAULT_JMX_FETCH_STATSD_PORT = 8125;
 
   public static final boolean DEFAULT_LOGS_INJECTION_ENABLED = false;
@@ -174,6 +179,8 @@ public class Config {
   @Getter private final boolean runtimeContextFieldInjection;
   @Getter private final Set<PropagationStyle> propagationStylesToExtract;
   @Getter private final Set<PropagationStyle> propagationStylesToInject;
+
+  @Getter private final boolean kafkaAttemptPropagation;
 
   @Getter private final boolean jmxFetchEnabled;
   @Getter private final List<String> jmxFetchMetricsConfigs;
@@ -252,6 +259,10 @@ public class Config {
             DEFAULT_PROPAGATION_STYLE_INJECT,
             PropagationStyle.class,
             true);
+
+    kafkaAttemptPropagation =
+        getBooleanSettingFromEnvironment(
+            KAFKA_ATTEMPT_PROPAGATION, DEFAULT_KAFKA_ATTEMPT_PROPAGATION);
 
     jmxFetchEnabled =
         getBooleanSettingFromEnvironment(JMX_FETCH_ENABLED, DEFAULT_JMX_FETCH_ENABLED);
@@ -341,6 +352,10 @@ public class Config {
         parsedPropagationStylesToInject == null
             ? parent.propagationStylesToInject
             : parsedPropagationStylesToInject;
+
+    kafkaAttemptPropagation =
+        getPropertyBooleanValue(
+            properties, KAFKA_ATTEMPT_PROPAGATION, parent.kafkaAttemptPropagation);
 
     jmxFetchEnabled =
         getPropertyBooleanValue(properties, JMX_FETCH_ENABLED, parent.jmxFetchEnabled);


### PR DESCRIPTION
In some environments [`maxUsableProduceMagic()`](https://github.com/signalfx/signalfx-java-tracing/blob/c02110a2a1d4847054f145ed2a2dbceb84844b19/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java#L78) may not have enough information to successfully disable context injection, causing undesired side effects for legacy record processing.

These changes add a `signalfx.instrumentation.kafka.attempt-propagation` property to disable injection and extraction attempts.