### PR TITLE
Trace annotation and MDC usability improvements

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -40,7 +40,7 @@ class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "AnnotationTracedCallable.call"
-          operationName "trace.annotation"
+          operationName "AnnotationTracedCallable.call"
         }
       }
     }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -356,7 +356,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "SayTracedHello\$1.call"
-          operationName "trace.annotation"
+          operationName "SayTracedHello\$1.call"
         }
       }
     }
@@ -377,7 +377,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "SayTracedHello\$1.call"
-          operationName "trace.annotation"
+          operationName "SayTracedHello\$1.call"
         }
         trace(1, 1) {
           span(0) {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.instrumentation.trace_annotation.TraceConfigInstrumentation
@@ -37,7 +38,7 @@ class TraceConfigTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           resourceName "ConfigTracedCallable.call"
-          operationName "trace.annotation"
+          operationName "ConfigTracedCallable.call"
         }
       }
     }

--- a/dd-java-agent/testing/src/test/groovy/TraceCorrelationTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/TraceCorrelationTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import datadog.opentracing.DDSpan
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.CorrelationIdentifier
@@ -12,14 +13,14 @@ class TraceCorrelationTest extends AgentTestRunner {
     DDSpan span = (DDSpan) scope.span()
 
     then:
-    CorrelationIdentifier.traceId == span.traceId
-    CorrelationIdentifier.spanId == span.spanId
+    CorrelationIdentifier.traceId == String.format("%016x", new BigInteger(span.traceId, 10))
+    CorrelationIdentifier.spanId == String.format("%016x", new BigInteger(span.spanId, 10))
 
     when:
     scope.close()
 
     then:
-    CorrelationIdentifier.traceId == "0"
-    CorrelationIdentifier.spanId == "0"
+    CorrelationIdentifier.traceId == "0000000000000000"
+    CorrelationIdentifier.spanId == "0000000000000000"
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/CorrelationIdentifier.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/CorrelationIdentifier.java
@@ -21,10 +21,10 @@ public class CorrelationIdentifier {
   }
 
   public static String getTraceId() {
-    return GlobalTracer.get().getTraceId();
+    return Ids.idToHex(GlobalTracer.get().getTraceId());
   }
 
   public static String getSpanId() {
-    return GlobalTracer.get().getSpanId();
+    return Ids.idToHex(GlobalTracer.get().getSpanId());
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/Ids.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Ids.java
@@ -1,4 +1,5 @@
-package datadog.trace.common.util;
+// Modified by SignalFx
+package datadog.trace.api;
 
 import java.math.BigInteger;
 

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/IdsTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/IdsTest.groovy
@@ -1,0 +1,41 @@
+// Modified by SignalFx
+package datadog.trace.api
+
+import datadog.trace.util.test.DDSpecification
+
+class IdsTest extends DDSpecification {
+
+  def "idToHex"() {
+    when:
+    def toHex = Ids.idToHex(toConvert)
+
+    then:
+    toHex == expected
+
+    where:
+    toConvert                                 | expected
+    "0"                                       | "0000000000000000"
+    "1"                                       | "0000000000000001"
+    "4294967295"                              | "00000000ffffffff"
+    "18446744073709551615"                    | "ffffffffffffffff"
+    "18446744073709551616"                    | "00000000000000010000000000000000"
+    "340282366920938463463374607431768211455" | "ffffffffffffffffffffffffffffffff"
+  }
+
+  def "hexToId"() {
+    when:
+    def toDec = Ids.hexToId(toConvert)
+
+    then:
+    toDec == expected
+
+    where:
+    toConvert                          | expected
+    "0000000000000000"                 | "0"
+    "0000000000000001"                 | "1"
+    "00000000ffffffff"                 | "4294967295"
+    "ffffffffffffffff"                 | "18446744073709551615"
+    "00000000000000010000000000000000" | "18446744073709551616"
+    "ffffffffffffffffffffffffffffffff" | "340282366920938463463374607431768211455"
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
@@ -10,7 +10,7 @@ import com.google.common.base.Strings;
 import datadog.opentracing.DDSpan;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
-import datadog.trace.common.util.Ids;
+import datadog.trace.api.Ids;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -333,8 +333,8 @@ for (def env : System.getenv().entrySet()) {
 }
 
 tasks.withType(Test).configureEach {
-  // All tests must complete within 2 minutes.
-  timeout = Duration.ofMinutes(2)
+  // All tests must complete within 3 minutes.
+  timeout = Duration.ofMinutes(3)
 
   // Disable all tests if skipTests property was specified
   onlyIf { !project.rootProject.hasProperty("skipTests") }


### PR DESCRIPTION
These changes ensure that non-DD trace annotations use the same behavior as that of `com.signalfx.tracing.api.Trace` regarding operation names, and also ensure that logged MDC entries use hex representation for active span and its trace ids (resolves https://github.com/signalfx/signalfx-java-tracing/issues/68).  The latter required relocating the ids helper to the api project to prevent an unwanted dependency on the agent.

Also bumping up test timeout to reduce flake.