### PR TITLE
Account for removed NoOp Transformer and Hibernate changes

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedProvider.java
@@ -84,6 +84,18 @@ public class FieldBackedProvider implements InstrumentationContextProvider {
   private static final String INJECTED_FIELDS_MARKER_CLASS_NAME =
       Utils.getInternalName(FieldBackedContextStoreAppliedMarker.class.getName());
 
+  private static final AgentBuilder.Transformer NOOP_TRANSFORMER =
+      new AgentBuilder.Transformer() {
+        @Override
+        public DynamicType.Builder<?> transform(
+            DynamicType.Builder<?> builder,
+            TypeDescription typeDescription,
+            ClassLoader classLoader,
+            JavaModule module) {
+          return builder;
+        }
+      };
+
   private static final Method CONTEXT_GET_METHOD;
   private static final Method GET_CONTEXT_STORE_METHOD;
 
@@ -358,7 +370,7 @@ public class FieldBackedProvider implements InstrumentationContextProvider {
                     safeHasSuperType(named(entry.getKey())).and(not(isInterface())),
                     instrumenter.classLoaderMatcher())
                 .and(safeToInjectFieldsMatcher())
-                .transform(AgentBuilder.Transformer.NoOp.INSTANCE);
+                .transform(NOOP_TRANSFORMER);
 
         /**
          * We inject helpers here as well as when instrumentation is applied to ensure that helpers

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -39,7 +39,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_USER" "sa"
             "$Tags.SPAN_KIND" "$Tags.SPAN_KIND_CLIENT"
-            "$Tags.DB_STATEMENT" "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_"
+            "$Tags.DB_STATEMENT" ~/select customer0_.id as id1_0_, customer0_.firstName as first[nN]am2_0_, customer0_.lastName as last[nN]ame3_0_ from Customer customer0_/
             "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
             defaultTags()
           }
@@ -114,7 +114,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_USER" "sa"
             "$Tags.SPAN_KIND" "$Tags.SPAN_KIND_CLIENT"
-            "$Tags.DB_STATEMENT" "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
+            "$Tags.DB_STATEMENT" ~/select customer0_.id as id1_0_0_, customer0_.firstName as first[nN]am2_0_0_, customer0_.lastName as last[nN]ame3_0_0_ from Customer customer0_ where customer0_.id=?/
             "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
             defaultTags()
           }
@@ -158,7 +158,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_USER" "sa"
             "$Tags.SPAN_KIND" "$Tags.SPAN_KIND_CLIENT"
-            "$Tags.DB_STATEMENT" "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_ where customer0_.lastName=?"
+            "$Tags.DB_STATEMENT" ~/select customer0_.id as id1_0_, customer0_.firstName as first[nN]am2_0_, customer0_.lastName as last[nN]ame3_0_ from Customer customer0_ where customer0_.lastName=?/
             "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
             defaultTags()
           }
@@ -183,7 +183,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_USER" "sa"
             "$Tags.SPAN_KIND" "$Tags.SPAN_KIND_CLIENT"
-            "$Tags.DB_STATEMENT" "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
+            "$Tags.DB_STATEMENT" ~/select customer0_.id as id1_0_0_, customer0_.firstName as first[nN]am2_0_0_, customer0_.lastName as last[nN]ame3_0_0_ from Customer customer0_ where customer0_.id=?/
             "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
+++ b/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/HibernateDecorator.java
@@ -47,6 +47,9 @@ public class HibernateDecorator extends OrmClientDecorator {
 
   @Override
   public String entityName(final Object entity) {
+    if (entity == null) {
+      return null;
+    }
     String name = null;
     final Set<String> annotations = new HashSet<>();
     for (final Annotation annotation : entity.getClass().getDeclaredAnnotations()) {


### PR DESCRIPTION
The latest hibernate-core release pulls in ByteBuddy 1.10.7, which obsoleted the noop transformer singleton: https://github.com/raphw/byte-buddy/commit/a88c34b0f16ffba99671afaeb2fe1f821fb7633d#diff-5c70b068f9fa1c336626a22ca79771d4L2157

These changes move its functionality into the `FieldBackedProvider` to avoid the loading failure:
```
java.lang.NoClassDefFoundError: net/bytebuddy/agent/builder/AgentBuilder$Transformer$NoOp
	at datadog.trace.agent.tooling.context.FieldBackedProvider.additionalInstrumentation(FieldBackedProvider.java:359)
	at datadog.trace.agent.tooling.Instrumenter$Default.instrument(Instrumenter.java:82)
	at datadog.trace.agent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:151)
```

Also pulling in a null check added upstream and update tests for last Hibernate release behavior.*