### PR TITLE
Adopt Zipkin kind enum

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -29,8 +29,8 @@ public class DDTags {
 
   // Used by ZipkinV2Api to prevent OT/instrumentation api dep
   public static final String SPAN_KIND = "span.kind";
-  public static final String SPAN_KIND_SERVER = "server";
-  public static final String SPAN_KIND_CLIENT = "client";
-  public static final String SPAN_KIND_PRODUCER = "producer";
-  public static final String SPAN_KIND_CONSUMER = "consumer";
+  public static final String SPAN_KIND_SERVER = "SERVER";
+  public static final String SPAN_KIND_CLIENT = "CLIENT";
+  public static final String SPAN_KIND_PRODUCER = "PRODUCER";
+  public static final String SPAN_KIND_CONSUMER = "CONSUMER";
 }

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
@@ -111,7 +111,7 @@ public class ZipkinV2Api implements Api {
       }
       String responseContent = sb.toString();
 
-      if (responseCode != 200) {
+      if (responseCode != 200 && responseCode != 202) {
         if (log.isDebugEnabled()) {
           log.debug(
               "Error while sending {} of {} traces to {}. Status: {}, Response: {}",
@@ -220,7 +220,7 @@ public class ZipkinV2Api implements Api {
     if (tags.containsKey(DDTags.SPAN_KIND)) {
       Object kindObj = tags.get(DDTags.SPAN_KIND);
       if (kindObj instanceof String) {
-        return (String) kindObj;
+        return ((String) kindObj).toUpperCase();
       }
     }
 

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/ZipkinV2ApiTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/ZipkinV2ApiTest.groovy
@@ -119,7 +119,7 @@ class ZipkinV2ApiTest extends DDSpecification {
       "annotations": [["timestamp" : 1000, "value": "{\"event\":\"some event\"}"], ["timestamp" : 2000, "value":"{\"another event\":1}"]],
       "name"     : "fakeOperation",
       "localEndpoint": ["serviceName": "fakeService"],
-      "kind"    : "CliEnt",
+      "kind"    : "CLIENT",
       "timestamp"    : 100,
     ])]
     [[SpanFactory.newSpanOf(100L).setTag("span.kind", "SerVeR")]] | [new TreeMap<>([
@@ -132,7 +132,7 @@ class ZipkinV2ApiTest extends DDSpecification {
       "annotations": [],
       "name"     : "fakeResource",
       "localEndpoint": ["serviceName": "fakeService"],
-      "kind"    : "SerVeR",
+      "kind"    : "SERVER",
       "timestamp"    : 100,
     ])]
   }


### PR DESCRIPTION
These changes ensure that the encoded zipkin span kind is uppercase to meet the v2 json specification.  Also add a 202 success check in the zipkin reporter.