### PR TITLE
Add Zipkin recorded value max length config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ content](https://docs.signalfx.com/en/latest/apm/apm-overview/apm-metadata.html)
 | `signalfx.integration.<name>.enabled=true` | none | Varies per instrumentation | `<name>` is the instrumentation name detailed in the supported libraries. |
 | `signalfx.span.tags` | `SIGNALFX_SPAN_TAGS` | `null` | Comma-separated list of tags of the form `"key1:val1,key2:val2"` to be included in every reported span. |
 | `signalfx.db.statement.max.length` | `SIGNALFX_DB_STATEMENT_MAX_LENGTH` | `1024` | The maximum number of characters written for the OpenTracing `db.statement` tag. |
+| `signalfx.recorded.value.max.length` | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `12288` | The maximum number of characters for any Zipkin-encoded tagged or logged value. |
 
 **Note: System property values take priority over corresponding environment
 variables.**

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -108,6 +108,7 @@ public class Config {
 
   public static final String LOGS_INJECTION_ENABLED = "logs.injection";
   public static final String DB_STATEMENT_MAX_LENGTH = "db.statement.max.length";
+  public static final String RECORDED_VALUE_MAX_LENGTH = "recorded.value.max.length";
 
   public static final String SERVICE_TAG = "service";
   @Deprecated public static final String SERVICE = SERVICE_TAG; // To be removed in 0.34.0
@@ -184,6 +185,8 @@ public class Config {
   }
 
   public static final int DEFAULT_DB_STATEMENT_MAX_LENGTH = 1024;
+  public static final int DEFAULT_RECORDED_VALUE_MAX_LENGTH = 12288;
+
   /** A tag intended for internal use only, hence not added to the public api DDTags class. */
   private static final String INTERNAL_HOST_NAME = "_dd.hostname";
 
@@ -247,6 +250,7 @@ public class Config {
   @Getter private final boolean reportHostName;
 
   @Getter private final Integer dbStatementMaxLength;
+  @Getter private final Integer recordedValueMaxLength;
 
   // Read order: System Properties -> Env Variables, [-> default value]
   @Getter private final String traceAnnotations;
@@ -380,6 +384,10 @@ public class Config {
 
     dbStatementMaxLength =
         getIntegerSettingFromEnvironment(DB_STATEMENT_MAX_LENGTH, DEFAULT_DB_STATEMENT_MAX_LENGTH);
+
+    recordedValueMaxLength =
+        getIntegerSettingFromEnvironment(
+            RECORDED_VALUE_MAX_LENGTH, DEFAULT_RECORDED_VALUE_MAX_LENGTH);
 
     traceAnnotations = getSettingFromEnvironment(TRACE_ANNOTATIONS, DEFAULT_TRACE_ANNOTATIONS);
 
@@ -522,6 +530,10 @@ public class Config {
 
     dbStatementMaxLength =
         getPropertyIntegerValue(properties, DB_STATEMENT_MAX_LENGTH, parent.dbStatementMaxLength);
+
+    recordedValueMaxLength =
+        getPropertyIntegerValue(
+            properties, RECORDED_VALUE_MAX_LENGTH, parent.recordedValueMaxLength);
 
     traceAnnotations = properties.getProperty(TRACE_ANNOTATIONS, parent.traceAnnotations);
 

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -57,6 +57,8 @@ import static datadog.trace.api.Config.WRITER_TYPE
 import static datadog.trace.api.Config.HEALTH_METRICS_ENABLED
 import static datadog.trace.api.Config.HEALTH_METRICS_STATSD_HOST
 import static datadog.trace.api.Config.HEALTH_METRICS_STATSD_PORT
+import static datadog.trace.api.Config.RECORDED_VALUE_MAX_LENGTH
+import static datadog.trace.api.Config.DEFAULT_RECORDED_VALUE_MAX_LENGTH
 
 class ConfigTest extends DDSpecification {
   @Rule
@@ -79,6 +81,7 @@ class ConfigTest extends DDSpecification {
   private static final SIGNALFX_DB_STATEMENT_MAX_LENGTH = "SIGNALFX_DB_STATEMENT_MAX_LENGTH"
   private static final SIGNALFX_KAFKA_ATTEMPT_PROPAGATION_ENV = "SIGNALFX_INSTRUMENTATION_KAFKA_ATTEMPT_PROPAGATION"
   private static final SIGNALFX_REDIS_CAPTURE_COMMAND_ARGUMENTS = "SIGNALFX_INSTRUMENTATION_REDIS_CAPTURE_COMMAND_ARGUMENTS"
+  private static final SIGNALFX_RECORDED_VALUE_MAX_LENGTH = "SIGNALFX_RECORDED_VALUE_MAX_LENGTH"
 
   def "verify defaults"() {
     when:
@@ -126,6 +129,7 @@ class ConfigTest extends DDSpecification {
     config.dbStatementMaxLength == DEFAULT_DB_STATEMENT_MAX_LENGTH
     config.kafkaAttemptPropagation == DEFAULT_KAFKA_ATTEMPT_PROPAGATION
     config.redisCaptureCommandArguments == DEFAULT_REDIS_CAPTURE_COMMAND_ARGUMENTS
+    config.recordedValueMaxLength == DEFAULT_RECORDED_VALUE_MAX_LENGTH
 
     where:
     provider << [{ new Config() }, { Config.get() }, {
@@ -171,6 +175,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(DB_STATEMENT_MAX_LENGTH, "100")
     prop.setProperty(KAFKA_ATTEMPT_PROPAGATION, "false")
     prop.setProperty(REDIS_CAPTURE_COMMAND_ARGUMENTS, "false")
+    prop.setProperty(RECORDED_VALUE_MAX_LENGTH, "10")
     prop.setProperty(HEALTH_METRICS_ENABLED, "false")
     prop.setProperty(HEALTH_METRICS_STATSD_HOST, "metrics statsd host")
     prop.setProperty(HEALTH_METRICS_STATSD_PORT, "654")
@@ -209,6 +214,7 @@ class ConfigTest extends DDSpecification {
     config.jmxFetchStatsdPort == 321
     config.dbStatementMaxLength == 100
     config.kafkaAttemptPropagation == false
+    config.recordedValueMaxLength == 10
     config.redisCaptureCommandArguments == false
     config.healthMetricsEnabled == false
     config.healthMetricsStatsdHost == "metrics statsd host"
@@ -254,6 +260,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + DB_STATEMENT_MAX_LENGTH, "100") // SFX
     System.setProperty(PREFIX + KAFKA_ATTEMPT_PROPAGATION, "false") // SFX
     System.setProperty(PREFIX + REDIS_CAPTURE_COMMAND_ARGUMENTS, "false") // SFX
+    System.setProperty(PREFIX + RECORDED_VALUE_MAX_LENGTH, "100") // SFX
     System.setProperty(PREFIX + JMX_FETCH_ENABLED, "false")
     System.setProperty(PREFIX + JMX_FETCH_METRICS_CONFIGS, "/foo.yaml,/bar.yaml")
     System.setProperty(PREFIX + JMX_FETCH_CHECK_PERIOD, "100")
@@ -305,6 +312,7 @@ class ConfigTest extends DDSpecification {
     config.dbStatementMaxLength == 100
     config.kafkaAttemptPropagation == false
     config.redisCaptureCommandArguments == false
+    config.recordedValueMaxLength == 100
 
     where:
     prefix      | _
@@ -325,6 +333,7 @@ class ConfigTest extends DDSpecification {
     environmentVariables.set(SIGNALFX_DB_STATEMENT_MAX_LENGTH, "100")
     environmentVariables.set(SIGNALFX_KAFKA_ATTEMPT_PROPAGATION_ENV, "false")
     environmentVariables.set(SIGNALFX_REDIS_CAPTURE_COMMAND_ARGUMENTS, "false")
+    environmentVariables.set(SIGNALFX_RECORDED_VALUE_MAX_LENGTH, "1000")
 
     when:
     def config = new Config()
@@ -341,6 +350,7 @@ class ConfigTest extends DDSpecification {
     config.dbStatementMaxLength == 100
     config.kafkaAttemptPropagation == false
     config.redisCaptureCommandArguments == false
+    config.recordedValueMaxLength == 1000
   }
 
   def "malformed endpoint url fails"() {


### PR DESCRIPTION
These changes introduce the `recorded.value.max.length` config option to prevent Zipkin-encoded tag and log values from exceeding a specified size (default of 12288 chars).