### PR TITLE
Add Trace annotation blacklist configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ content](https://docs.signalfx.com/en/latest/apm/apm-overview/apm-metadata.html)
 | `signalfx.span.tags` | `SIGNALFX_SPAN_TAGS` | `null` | Comma-separated list of tags of the form `"key1:val1,key2:val2"` to be included in every reported span. |
 | `signalfx.db.statement.max.length` | `SIGNALFX_DB_STATEMENT_MAX_LENGTH` | `1024` | The maximum number of characters written for the OpenTracing `db.statement` tag. |
 | `signalfx.recorded.value.max.length` | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `12288` | The maximum number of characters for any Zipkin-encoded tagged or logged value. |
+| `signalfx.trace.annotated.method.blacklist` | `SIGNALFX_TRACE_ANNOTATED_METHOD_BLACKLIST` | `null` | Prevent `@Trace` annotation functionality for the target method string of format `package.OuterClass[methodOne,methodTwo];other.package.OuterClass$InnerClass[methodThree];*` (`;` is required). |
 
 **Note: System property values take priority over corresponding environment
 variables.**
@@ -155,6 +156,43 @@ headers](https://github.com/openzipkin/b3-propagation).
 See [our example applications that use
 this utility](https://github.com/signalfx/tracing-examples/tree/master/signalfx-tracing/signalfx-java-tracing) for
 more details on how to use and configure the SignalFx Java Agent.
+
+### Trace Annotation
+
+In cases where you'd like to gain some of the benefits of custom instrumentation without
+using the OpenTracing `GlobalTracer` and API directly, we offer a `@Trace` annotation you
+can use where desired:
+
+```java
+import com.signalfx.tracing.api.Trace;
+
+public class MyClass {
+  @Trace
+  public void MyLogic() {
+      <...>
+  }
+}
+```
+
+Each time an annotated method is invoked, a span denoting its duration and detailing any thrown
+exceptions will be produced.  This utility is provided assuming you've added the `signalfx-trace-api`
+dependency matching the version of your Java Agent:
+
+```
+Maven:
+<dependency>
+   <groupId>com.signalfx.public</groupId>
+   <artifactId>signalfx-trace-api</artifactId>
+   <version>MyAgentVersion</version>
+   <scope>provided</scope>
+</dependency>
+
+Gradle:
+compileOnly group: 'com.signalfx.public', name: 'signalfx-trace-api', version: 'MyAgentVersion'
+```
+
+This annotation can be disabled at runtime using the `signalfx.trace.annotated.method.blacklist` property
+and associated environment variable as detailed [above](#configuration-and-usage).
 
 # License and Versioning
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ content](https://docs.signalfx.com/en/latest/apm/apm-overview/apm-metadata.html)
 | `signalfx.span.tags` | `SIGNALFX_SPAN_TAGS` | `null` | Comma-separated list of tags of the form `"key1:val1,key2:val2"` to be included in every reported span. |
 | `signalfx.db.statement.max.length` | `SIGNALFX_DB_STATEMENT_MAX_LENGTH` | `1024` | The maximum number of characters written for the OpenTracing `db.statement` tag. |
 | `signalfx.recorded.value.max.length` | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `12288` | The maximum number of characters for any Zipkin-encoded tagged or logged value. |
-| `signalfx.trace.annotated.method.blacklist` | `SIGNALFX_TRACE_ANNOTATED_METHOD_BLACKLIST` | `null` | Prevent `@Trace` annotation functionality for the target method string of format `package.OuterClass[methodOne,methodTwo];other.package.OuterClass$InnerClass[methodThree];*` (`;` is required). |
+| `signalfx.trace.annotated.method.blacklist` | `SIGNALFX_TRACE_ANNOTATED_METHOD_BLACKLIST` | `null` | Prevent `@Trace` annotation functionality for the target method string of format `package.OuterClass[methodOne,methodTwo];other.package.OuterClass$InnerClass[*];` (`;` is required and `*` for all methods in class). |
 
 **Note: System property values take priority over corresponding environment
 variables.**

--- a/dd-java-agent/instrumentation/jsp-2.3/jsp-2.3.gradle
+++ b/dd-java-agent/instrumentation/jsp-2.3/jsp-2.3.gradle
@@ -32,7 +32,7 @@ dependencies {
 
   latestDepTestCompile group: 'javax.servlet.jsp', name: 'javax.servlet.jsp-api', version: '+'
   latestDepTestCompile group: 'javax.servlet', name: 'javax.servlet-api', version: '+'
-  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '+'
-  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '+'
-  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-logging-juli', version: '+'
+  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.+'
+  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: '9.+'
+  latestDepTestCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-logging-juli', version: '9.+'
 }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationUtils.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationUtils.java
@@ -1,0 +1,65 @@
+// Modified by SignalFx
+package datadog.trace.instrumentation.trace_annotation;
+
+import datadog.trace.api.Config;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TraceAnnotationUtils {
+
+  public static final Map<String, Set<String>> classMethodBlacklist =
+      getClassMethodMap(Config.get().getAnnotatedMethodBlacklist());
+
+  static final String PACKAGE_CLASS_NAME_REGEX = "[\\w.\\$]+";
+  private static final String METHOD_LIST_REGEX = "\\s*(?:\\w+\\s*,)*\\s*(?:\\w+\\s*,?)\\s*";
+  private static final String CONFIG_FORMAT =
+      "(?:\\s*"
+          + PACKAGE_CLASS_NAME_REGEX
+          + "\\["
+          + METHOD_LIST_REGEX
+          + "\\]\\s*;)*\\s*"
+          + PACKAGE_CLASS_NAME_REGEX
+          + "\\["
+          + METHOD_LIST_REGEX
+          + "\\]\\s*;?\\s*";
+
+  public static Map<String, Set<String>> getClassMethodMap(final String configString) {
+    if (configString == null || configString.trim().isEmpty()) {
+      return Collections.emptyMap();
+    } else if (!configString.matches(CONFIG_FORMAT)) {
+      log.warn(
+          "Invalid trace method config '{}'. Must match 'package.Class$Name[method1,method2];*'.",
+          configString);
+      return Collections.emptyMap();
+    } else {
+      final Map<String, Set<String>> toTrace = new HashMap<>(0);
+      final String[] classMethods = configString.split(";", -1);
+      for (final String classMethod : classMethods) {
+        if (classMethod.trim().isEmpty()) {
+          continue;
+        }
+        final String[] splitClassMethod = classMethod.split("\\[", -1);
+        final String className = splitClassMethod[0];
+        final String method = splitClassMethod[1].trim();
+        final String methodNames = method.substring(0, method.length() - 1);
+        final String[] splitMethodNames = methodNames.split(",", -1);
+        final Set<String> trimmedMethodNames = new HashSet<>(splitMethodNames.length);
+        for (final String methodName : splitMethodNames) {
+          final String trimmedMethodName = methodName.trim();
+          if (!trimmedMethodName.isEmpty()) {
+            trimmedMethodNames.add(trimmedMethodName);
+          }
+        }
+        if (!trimmedMethodNames.isEmpty()) {
+          toTrace.put(className.trim(), trimmedMethodNames);
+        }
+      }
+      return Collections.unmodifiableMap(toTrace);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
@@ -2,7 +2,7 @@
 package datadog.trace.instrumentation.trace_annotation;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
-import static datadog.trace.instrumentation.trace_annotation.TraceConfigInstrumentation.PACKAGE_CLASS_NAME_REGEX;
+import static datadog.trace.instrumentation.trace_annotation.TraceAnnotationUtils.PACKAGE_CLASS_NAME_REGEX;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.is;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
@@ -87,7 +87,9 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Default 
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "datadog.trace.agent.decorator.BaseDecorator", packageName + ".TraceDecorator",
+      "datadog.trace.agent.decorator.BaseDecorator",
+      packageName + ".TraceAnnotationUtils",
+      packageName + ".TraceDecorator",
     };
   }
 

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
@@ -89,6 +89,7 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Default 
     return new String[] {
       "datadog.trace.agent.decorator.BaseDecorator",
       packageName + ".TraceAnnotationUtils",
+      packageName + ".TraceAnnotationUtils$ContainsEverythingSet",
       packageName + ".TraceDecorator",
     };
   }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -78,6 +78,7 @@ public class TraceConfigInstrumentation implements Instrumenter {
       return new String[] {
         "datadog.trace.agent.decorator.BaseDecorator",
         packageName + ".TraceAnnotationUtils",
+        packageName + ".TraceAnnotationUtils$ContainsEverythingSet",
         packageName + ".TraceDecorator",
       };
     }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -1,11 +1,11 @@
+// Modified by SignalFx
 package datadog.trace.instrumentation.trace_annotation;
 
 import static datadog.trace.agent.tooling.ByteBuddyElementMatchers.safeHasSuperType;
+import static datadog.trace.instrumentation.trace_annotation.TraceAnnotationUtils.getClassMethodMap;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
 import java.util.Collections;
@@ -31,58 +31,11 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public class TraceConfigInstrumentation implements Instrumenter {
 
-  static final String PACKAGE_CLASS_NAME_REGEX = "[\\w.\\$]+";
-  private static final String METHOD_LIST_REGEX = "\\s*(?:\\w+\\s*,)*\\s*(?:\\w+\\s*,?)\\s*";
-  private static final String CONFIG_FORMAT =
-      "(?:\\s*"
-          + PACKAGE_CLASS_NAME_REGEX
-          + "\\["
-          + METHOD_LIST_REGEX
-          + "\\]\\s*;)*\\s*"
-          + PACKAGE_CLASS_NAME_REGEX
-          + "\\["
-          + METHOD_LIST_REGEX
-          + "\\]\\s*;?\\s*";
-
   private final Map<String, Set<String>> classMethodsToTrace;
 
   public TraceConfigInstrumentation() {
     final String configString = Config.get().getTraceMethods();
-    if (configString == null || configString.trim().isEmpty()) {
-      classMethodsToTrace = Collections.emptyMap();
-
-    } else if (!configString.matches(CONFIG_FORMAT)) {
-      log.warn(
-          "Invalid trace method config '{}'. Must match 'package.Class$Name[method1,method2];*'.",
-          configString);
-      classMethodsToTrace = Collections.emptyMap();
-
-    } else {
-      final Map<String, Set<String>> toTrace = Maps.newHashMap();
-      final String[] classMethods = configString.split(";", -1);
-      for (final String classMethod : classMethods) {
-        if (classMethod.trim().isEmpty()) {
-          continue;
-        }
-        final String[] splitClassMethod = classMethod.split("\\[", -1);
-        final String className = splitClassMethod[0];
-        final String method = splitClassMethod[1].trim();
-        final String methodNames = method.substring(0, method.length() - 1);
-        final String[] splitMethodNames = methodNames.split(",", -1);
-        final Set<String> trimmedMethodNames =
-            Sets.newHashSetWithExpectedSize(splitMethodNames.length);
-        for (final String methodName : splitMethodNames) {
-          final String trimmedMethodName = methodName.trim();
-          if (!trimmedMethodName.isEmpty()) {
-            trimmedMethodNames.add(trimmedMethodName);
-          }
-        }
-        if (!trimmedMethodNames.isEmpty()) {
-          toTrace.put(className.trim(), trimmedMethodNames);
-        }
-      }
-      classMethodsToTrace = Collections.unmodifiableMap(toTrace);
-    }
+    classMethodsToTrace = getClassMethodMap(configString);
   }
 
   @Override
@@ -123,7 +76,9 @@ public class TraceConfigInstrumentation implements Instrumenter {
     @Override
     public String[] helperClassNames() {
       return new String[] {
-        "datadog.trace.agent.decorator.BaseDecorator", packageName + ".TraceDecorator",
+        "datadog.trace.agent.decorator.BaseDecorator",
+        packageName + ".TraceAnnotationUtils",
+        packageName + ".TraceDecorator",
       };
     }
 

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -6,6 +6,8 @@ import datadog.trace.api.Trace
 import datadog.trace.instrumentation.api.Tags
 import dd.test.trace.annotation.SayTracedHello
 
+import spock.lang.Shared
+
 import java.util.concurrent.Callable
 
 class TraceAnnotationsTest extends AgentTestRunner {
@@ -14,6 +16,13 @@ class TraceAnnotationsTest extends AgentTestRunner {
     ConfigUtils.updateConfig {
       System.clearProperty("dd.trace.annotations")
     }
+  }
+
+  @Shared
+  def methodsBlacklisted
+
+  def setupSpec() {
+    methodsBlacklisted = System.getProperty("signalfx.trace.annotated.method.blacklist") != null
   }
 
   def "test simple case annotations"() {
@@ -45,18 +54,22 @@ class TraceAnnotationsTest extends AgentTestRunner {
     SayTracedHello.sayHA()
 
     expect:
-    assertTraces(1) {
-      trace(0, 1) {
-        span(0) {
-          serviceName "test"
-          resourceName "SayTracedHello.sayHA"
-          operationName "SAY_HA"
-          spanType "DB"
-          parent()
-          errored false
-          tags {
-            "$Tags.COMPONENT" "trace"
-            defaultTags()
+    if (methodsBlacklisted) {
+      assertTraces(0) {}
+    } else {
+      assertTraces(1) {
+        trace(0, 1) {
+          span(0) {
+            serviceName "test"
+            resourceName "SayTracedHello.sayHA"
+            operationName "SAY_HA"
+            spanType "DB"
+            parent()
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
           }
         }
       }
@@ -163,37 +176,64 @@ class TraceAnnotationsTest extends AgentTestRunner {
 
     then:
     assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
-          resourceName "SayTracedHello.sayHELLOsayHA"
-          operationName "NEW_TRACE"
-          parent()
-          errored false
-          tags {
-            "$Tags.COMPONENT" "trace"
-            defaultTags()
+      if (methodsBlacklisted) {
+        trace(0, 2) {
+          span(0) {
+            resourceName "SayTracedHello.sayHELLOsayHA"
+            operationName "NEW_TRACE"
+            spanType "DB"
+            parent()
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
+          }
+          span(1) {
+            serviceName "test"
+            resourceName "SayTracedHello.sayHello"
+            operationName "trace.annotation"
+            childOf span(0)
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
           }
         }
-        span(1) {
-          resourceName "SayTracedHello.sayHA"
-          operationName "SAY_HA"
-          spanType "DB"
-          childOf span(0)
-          errored false
-          tags {
-            "$Tags.COMPONENT" "trace"
-            defaultTags()
+      } else {
+        trace(0, 3) {
+          span(0) {
+            resourceName "SayTracedHello.sayHELLOsayHA"
+            operationName "NEW_TRACE"
+            parent()
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
           }
-        }
-        span(2) {
-          serviceName "test"
-          resourceName "SayTracedHello.sayHello"
-          operationName "trace.annotation"
-          childOf span(0)
-          errored false
-          tags {
-            "$Tags.COMPONENT" "trace"
-            defaultTags()
+          span(1) {
+            resourceName "SayTracedHello.sayHA"
+            operationName "SAY_HA"
+            spanType "DB"
+            childOf span(0)
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
+          }
+          span(2) {
+            serviceName "test"
+            resourceName "SayTracedHello.sayHello"
+            operationName "trace.annotation"
+            childOf span(0)
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
           }
         }
       }
@@ -206,38 +246,55 @@ class TraceAnnotationsTest extends AgentTestRunner {
     SayTracedHello.sayHELLOsayHAWithResource()
 
     then:
-    assertTraces(1) {
-      trace(0, 3) {
-        span(0) {
-          resourceName "WORLD"
-          operationName "NEW_TRACE"
-          parent()
-          errored false
-          tags {
-            "$Tags.COMPONENT" "trace"
-            defaultTags()
+    if (methodsBlacklisted) {
+      assertTraces(1) {
+        trace(0, 1) {
+          span(0) {
+            resourceName "SayTracedHello.sayHello"
+            operationName "trace.annotation"
+            parent()
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
           }
         }
-        span(1) {
-          resourceName "SayTracedHello.sayHA"
-          operationName "SAY_HA"
-          spanType "DB"
-          childOf span(0)
-          errored false
-          tags {
-            "$Tags.COMPONENT" "trace"
-            defaultTags()
+      }
+    } else {
+      assertTraces(1) {
+        trace(0, 3) {
+          span(0) {
+            resourceName "WORLD"
+            operationName "NEW_TRACE"
+            parent()
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
           }
-        }
-        span(2) {
-          serviceName "test"
-          resourceName "SayTracedHello.sayHello"
-          operationName "trace.annotation"
-          childOf span(0)
-          errored false
-          tags {
-            "$Tags.COMPONENT" "trace"
-            defaultTags()
+          span(1) {
+            resourceName "SayTracedHello.sayHA"
+            operationName "SAY_HA"
+            spanType "DB"
+            childOf span(0)
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
+          }
+          span(2) {
+            serviceName "test"
+            resourceName "SayTracedHello.sayHello"
+            operationName "trace.annotation"
+            childOf span(0)
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
           }
         }
       }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -445,4 +445,39 @@ class TraceAnnotationsTest extends AgentTestRunner {
       }
     }
   }
+
+  def "test inner class tracing"() {
+    when:
+    SayTracedHello.SomeInnerClass.one()
+
+    then:
+    if (methodsBlacklisted) {
+      assertTraces(0) {}
+    } else {
+      assertTraces(1) {
+        trace(0, 2) {
+          span(0) {
+            resourceName "SomeInnerClass.one"
+            operationName "trace.annotation"
+            parent()
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
+          }
+          span(1) {
+            resourceName "SomeInnerClass.two"
+            operationName "trace.annotation"
+            childOf span(0)
+            errored false
+            tags {
+              "$Tags.COMPONENT" "trace"
+              defaultTags()
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/SayTracedHello.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/SayTracedHello.java
@@ -97,4 +97,16 @@ public class SayTracedHello {
       }
     }.call();
   }
+
+  public static class SomeInnerClass {
+    @Trace
+    public static String one() {
+      return two();
+    }
+
+    @Trace
+    public static String two() {
+      return "Two!";
+    }
+  }
 }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/SayTracedHello.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/SayTracedHello.java
@@ -23,8 +23,10 @@ public class SayTracedHello {
 
   @Trace(operationName = "SAY_HA")
   public static String sayHA() {
-    activeSpan().setTag(DDTags.SERVICE_NAME, "test");
-    activeSpan().setTag(DDTags.SPAN_TYPE, "DB");
+    if (activeSpan() != null) {
+      activeSpan().setTag(DDTags.SERVICE_NAME, "test");
+      activeSpan().setTag(DDTags.SPAN_TYPE, "DB");
+    }
     return "HA!!";
   }
 
@@ -54,7 +56,9 @@ public class SayTracedHello {
 
   @Trace(operationName = "NEW_TRACE", resourceName = "WORLD")
   public static String sayHELLOsayHAWithResource() {
-    activeSpan().setTag(DDTags.SERVICE_NAME, "test2");
+    if (activeSpan() != null) {
+      activeSpan().setTag(DDTags.SERVICE_NAME, "test2");
+    }
     return sayHello() + sayHA();
   }
 

--- a/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
+++ b/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
@@ -13,7 +13,7 @@ testSets {
 }
 
 tasks.getByName('propertyTest').configure {
-  jvmArgs "-Dsignalfx.trace.annotated.method.blacklist=something.That[doesnt,exist];dd.test.trace.annotation.SayTracedHello[doesntExist,sayHA,sayHELLOsayHAWithResource,alsoDoesntExist];"
+  jvmArgs '-Dsignalfx.trace.annotated.method.blacklist=something.That[doesnt,exist];dd.test.trace.annotation.SayTracedHello[doesntExist,sayHA,sayHELLOsayHAWithResource,alsoDoesntExist];dd.test.trace.annotation.SayTracedHello$SomeInnerClass[*];'
 }
 
 test.dependsOn(propertyTest)

--- a/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
+++ b/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
@@ -1,5 +1,19 @@
+// Modified by SignalFx
 apply from: "${rootDir}/gradle/java.gradle"
+apply plugin: 'org.unbroken-dome.test-sets'
 
 dependencies {
   testCompile group: 'com.newrelic.agent.java', name: 'newrelic-api', version: '+'
 }
+
+testSets {
+  propertyTest {
+    dirName = 'test'
+  }
+}
+
+tasks.getByName('propertyTest').configure {
+  jvmArgs "-Dsignalfx.trace.annotated.method.blacklist=something.That[doesnt,exist];dd.test.trace.annotation.SayTracedHello[doesntExist,sayHA,sayHELLOsayHAWithResource,alsoDoesntExist];"
+}
+
+test.dependsOn(propertyTest)

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -69,6 +69,7 @@ public class Config {
   public static final String JMX_TAGS = "trace.jmx.tags";
   public static final String TRACE_ANALYTICS_ENABLED = "trace.analytics.enabled";
   public static final String TRACE_ANNOTATIONS = "trace.annotations";
+  public static final String ANNOTATED_METHOD_BLACKLIST = "trace.annotated.method.blacklist";
   public static final String TRACE_EXECUTORS_ALL = "trace.executors.all";
   public static final String TRACE_EXECUTORS = "trace.executors";
   public static final String TRACE_METHODS = "trace.methods";
@@ -172,6 +173,7 @@ public class Config {
 
   private static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
   private static final String DEFAULT_TRACE_ANNOTATIONS = null;
+  private static final String DEFAULT_ANNOTATED_METHOD_BLACKLIST = null;
   private static final boolean DEFAULT_TRACE_EXECUTORS_ALL = false;
   private static final String DEFAULT_TRACE_EXECUTORS = "";
   private static final String DEFAULT_TRACE_METHODS = null;
@@ -254,6 +256,7 @@ public class Config {
 
   // Read order: System Properties -> Env Variables, [-> default value]
   @Getter private final String traceAnnotations;
+  @Getter private final String annotatedMethodBlacklist;
 
   @Getter private final String traceMethods;
 
@@ -390,6 +393,8 @@ public class Config {
             RECORDED_VALUE_MAX_LENGTH, DEFAULT_RECORDED_VALUE_MAX_LENGTH);
 
     traceAnnotations = getSettingFromEnvironment(TRACE_ANNOTATIONS, DEFAULT_TRACE_ANNOTATIONS);
+    annotatedMethodBlacklist =
+        getSettingFromEnvironment(ANNOTATED_METHOD_BLACKLIST, DEFAULT_ANNOTATED_METHOD_BLACKLIST);
 
     traceMethods = getSettingFromEnvironment(TRACE_METHODS, DEFAULT_TRACE_METHODS);
 
@@ -536,6 +541,8 @@ public class Config {
             properties, RECORDED_VALUE_MAX_LENGTH, parent.recordedValueMaxLength);
 
     traceAnnotations = properties.getProperty(TRACE_ANNOTATIONS, parent.traceAnnotations);
+    annotatedMethodBlacklist =
+        properties.getProperty(ANNOTATED_METHOD_BLACKLIST, parent.annotatedMethodBlacklist);
 
     traceMethods = properties.getProperty(TRACE_METHODS, parent.traceMethods);
 


### PR DESCRIPTION
These changes add a new configuration property `signalfx.trace.annotated.method.blacklist` that will turn the existing `TraceAdvice` methods into a noop.  This approach was taken to avoid the complexity of converting the `TraceAnnotationInstrumentation` to something like the current `TraceConfigInstrumentation`.  It will also ensure that (in)directly annotated methods will not be traced across instrumentation approaches.*

Also cherry picking restricting latest Tomcat test dependencies.