### PR TITLE
Add maxSpansPerTrace config parameter, with a default of 2000.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ content](https://docs.signalfx.com/en/latest/apm/apm-overview/apm-metadata.html)
 | `signalfx.db.statement.max.length` | `SIGNALFX_DB_STATEMENT_MAX_LENGTH` | `1024` | The maximum number of characters written for the OpenTracing `db.statement` tag. |
 | `signalfx.recorded.value.max.length` | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `12288` | The maximum number of characters for any Zipkin-encoded tagged or logged value. |
 | `signalfx.trace.annotated.method.blacklist` | `SIGNALFX_TRACE_ANNOTATED_METHOD_BLACKLIST` | `null` | Prevent `@Trace` annotation functionality for the target method string of format `package.OuterClass[methodOne,methodTwo];other.package.OuterClass$InnerClass[*];` (`;` is required and `*` for all methods in class). |
+| `signalfx.max.spans.per.trace` | `SIGNALFX_MAX_SPANS_PER_TRACE` | `2000` | Drop (don't deliver) spans with more traces than this. Intended to prevent runaway traces from flooding upstream systems. |
 
 **Note: System property values take priority over corresponding environment
 variables.**

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ content](https://docs.signalfx.com/en/latest/apm/apm-overview/apm-metadata.html)
 | `signalfx.db.statement.max.length` | `SIGNALFX_DB_STATEMENT_MAX_LENGTH` | `1024` | The maximum number of characters written for the OpenTracing `db.statement` tag. |
 | `signalfx.recorded.value.max.length` | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `12288` | The maximum number of characters for any Zipkin-encoded tagged or logged value. |
 | `signalfx.trace.annotated.method.blacklist` | `SIGNALFX_TRACE_ANNOTATED_METHOD_BLACKLIST` | `null` | Prevent `@Trace` annotation functionality for the target method string of format `package.OuterClass[methodOne,methodTwo];other.package.OuterClass$InnerClass[*];` (`;` is required and `*` for all methods in class). |
-| `signalfx.max.spans.per.trace` | `SIGNALFX_MAX_SPANS_PER_TRACE` | `2000` | Drop (don't deliver) spans with more traces than this. Intended to prevent runaway traces from flooding upstream systems. |
+| `signalfx.max.spans.per.trace` | `SIGNALFX_MAX_SPANS_PER_TRACE` | `2000` | Drop (don't deliver) traces with more spans than this. Intended to prevent runaway traces from flooding upstream systems. |
 
 **Note: System property values take priority over corresponding environment
 variables.**

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -157,7 +157,7 @@ public class Config {
   private static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
   private static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;
   private static final String DEFAULT_SPLIT_BY_TAGS = "";
-  private static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
+  public static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   private static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.B3.name();
   private static final String DEFAULT_PROPAGATION_STYLE_INJECT = PropagationStyle.B3.name();
   private static final boolean DEFAULT_JMX_FETCH_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -117,7 +117,7 @@ public class Config {
   public static final String LANGUAGE_TAG_KEY = "language";
   public static final String LANGUAGE_TAG_VALUE = "jvm";
 
-  public static final String MAX_SPANS_PER_TRACE = "maxSpansPerTrace";
+  public static final String MAX_SPANS_PER_TRACE = "max.spans.per.trace";
   public static final Integer DEFAULT_MAX_SPANS_PER_TRACE = 2000;
 
   public static final String DEFAULT_SERVICE_NAME = "unnamed-java-app";

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -117,6 +117,9 @@ public class Config {
   public static final String LANGUAGE_TAG_KEY = "language";
   public static final String LANGUAGE_TAG_VALUE = "jvm";
 
+  public static final String MAX_SPANS_PER_TRACE = "maxSpansPerTrace";
+  public static final Integer DEFAULT_MAX_SPANS_PER_TRACE = 2000;
+
   public static final String DEFAULT_SERVICE_NAME = "unnamed-java-app";
 
   public static final String TRACING_LIBRARY_KEY = "signalfx.tracing.library";
@@ -265,6 +268,8 @@ public class Config {
 
   @Getter private final boolean traceAnalyticsEnabled;
 
+  @Getter private final Integer maxSpansPerTrace;
+
   // Values from an optionally provided properties file
   private static Properties propertiesFromConfigFile;
 
@@ -405,6 +410,9 @@ public class Config {
 
     traceAnalyticsEnabled =
         getBooleanSettingFromEnvironment(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
+
+    maxSpansPerTrace =
+        getIntegerSettingFromEnvironment(MAX_SPANS_PER_TRACE, DEFAULT_MAX_SPANS_PER_TRACE);
 
     log.debug("New instance: {}", this);
   }
@@ -552,6 +560,9 @@ public class Config {
 
     traceAnalyticsEnabled =
         getPropertyBooleanValue(properties, TRACE_ANALYTICS_ENABLED, parent.traceAnalyticsEnabled);
+
+    maxSpansPerTrace =
+        getPropertyIntegerValue(properties, MAX_SPANS_PER_TRACE, DEFAULT_MAX_SPANS_PER_TRACE);
 
     log.debug("New instance: {}", this);
   }

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -15,6 +15,7 @@ import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
 import spock.lang.Ignore
 
+import static datadog.trace.api.Config.DEFAULT_MAX_SPANS_PER_TRACE
 import static datadog.trace.api.Config.DEFAULT_SERVICE_NAME
 import static datadog.trace.api.Config.HEADER_TAGS
 import static datadog.trace.api.Config.HEALTH_METRICS_ENABLED
@@ -178,4 +179,26 @@ class DDTracerTest extends DDSpecification {
     child.finish()
     root.finish()
   }
+
+  def "spans per trace are capped at writing"() {
+    setup:
+    def writer = new ListWriter()
+    def tracer = new DDTracer('my_service', writer, new AllSampler())
+    // one below the limit
+    def ok = tracer.buildSpan("ok").start()
+    tracer.buildSpan("ok.child").asChildOf(ok).start().finish()
+    ok.finish()
+
+    // and one above it
+    def tooBig = tracer.buildSpan("tooBig").start()
+    for (int i = 0; i < Config.DEFAULT_MAX_SPANS_PER_TRACE; i++) {
+      tracer.buildSpan("tooBig.child" + i).asChildOf(tooBig).start().finish()
+    }
+    tooBig.finish()
+
+    expect:
+    writer.size() == 1
+    writer.get(0).size() == 2 // parent+child
+  }
+
 }

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -184,7 +184,7 @@ class DDTracerTest extends DDSpecification {
   def "spans per trace are capped at writing"() {
     setup:
     def writer = new ListWriter()
-    def tracer = new DDTracer('my_service', writer, new AllSampler())
+    def tracer = new DDTracer('cap_span_writes', writer, new AllSampler())
     // one below the limit
     def ok = tracer.buildSpan("ok").start()
     tracer.buildSpan("ok.child").asChildOf(ok).start().finish()
@@ -200,12 +200,15 @@ class DDTracerTest extends DDSpecification {
     expect:
     writer.size() == 1
     writer.get(0).size() == 2 // parent+child
+
+    cleanup:
+    tracer.close()
   }
 
   def "partial writes are still eventually capped"() {
     setup:
     def writer = new ListWriter()
-    def tracer = new DDTracer('my_service', writer, new AllSampler(), Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Config.DEFAULT_PARTIAL_FLUSH_MIN_SPANS)
+    def tracer = new DDTracer('partial_write_test_cap', writer, new AllSampler(), Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Config.DEFAULT_PARTIAL_FLUSH_MIN_SPANS)
     // First cause a partial write
     def tooBigEventually = tracer.buildSpan("tooBigEventually").start()
     for(int i=0; i < Config.DEFAULT_PARTIAL_FLUSH_MIN_SPANS + 1; i++) {

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -183,7 +183,7 @@ class DDTracerTest extends DDSpecification {
   def "spans per trace are capped at writing"() {
     setup:
     def writer = new ListWriter()
-    def tracer = new DDTracer('cap_span_writes', writer, new AllSampler())
+    def tracer = new DDTracer(DEFAULT_SERVICE_NAME, writer, new AllSampler())
     // one below the limit
     def ok = tracer.buildSpan("ok").start()
     tracer.buildSpan("ok.child").asChildOf(ok).start().finish()
@@ -207,7 +207,7 @@ class DDTracerTest extends DDSpecification {
   def "partial writes are still eventually capped"() {
     setup:
     def writer = new ListWriter()
-    def tracer = new DDTracer('partial_write_test_cap', writer, new AllSampler(), Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Config.DEFAULT_PARTIAL_FLUSH_MIN_SPANS)
+    def tracer = new DDTracer(DEFAULT_SERVICE_NAME, writer, new AllSampler(), Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Config.DEFAULT_PARTIAL_FLUSH_MIN_SPANS)
     // First cause a partial write
     def tooBigEventually = tracer.buildSpan("tooBigEventually").start()
     for (int i = 0; i < Config.DEFAULT_PARTIAL_FLUSH_MIN_SPANS + 1; i++) {

--- a/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/DDTracerTest.groovy
@@ -3,6 +3,7 @@ package datadog.trace
 
 import datadog.opentracing.DDTracer
 import datadog.opentracing.propagation.HttpCodec
+import datadog.opentracing.scopemanager.ContinuableScope
 import datadog.trace.api.Config
 import datadog.trace.common.sampling.AllSampler
 import datadog.trace.common.sampling.RateByServiceSampler
@@ -199,6 +200,54 @@ class DDTracerTest extends DDSpecification {
     expect:
     writer.size() == 1
     writer.get(0).size() == 2 // parent+child
+  }
+
+  def "partial writes are still eventually capped"() {
+    setup:
+    def writer = new ListWriter()
+    def tracer = new DDTracer('my_service', writer, new AllSampler(), Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP, Config.DEFAULT_PARTIAL_FLUSH_MIN_SPANS)
+    // First cause a partial write
+    def tooBigEventually = tracer.buildSpan("tooBigEventually").start()
+    for(int i=0; i < Config.DEFAULT_PARTIAL_FLUSH_MIN_SPANS + 1; i++) {
+      tracer.buildSpan("tooBigEventually.child" + i).asChildOf(tooBigEventually).start().finish()
+    }
+    if (true) { // keep scope of copy+paste in check
+      def cont = tracer.buildSpan("tooBigEventually.cont").asChildOf(tooBigEventually).start()
+      def cscope = tracer.scopeManager().activate(cont)
+      ((ContinuableScope) cscope).setAsyncPropagation(true)
+      def continuation = ((ContinuableScope) cscope).capture()
+      continuation.activate().close() // causes partial write
+    }
+
+
+    assert writer.size() == 1
+    assert writer.get(0).size() >= Config.DEFAULT_PARTIAL_FLUSH_MIN_SPANS
+
+    // Then add a bunch more (over capping limit) and cause another (capped) partial write
+    for(int i=0; i < Config.DEFAULT_MAX_SPANS_PER_TRACE; i++) {
+      tracer.buildSpan("tooBigEventually.child.2." + i).asChildOf(tooBigEventually).start().finish()
+    }
+    if (true) {
+      def cont = tracer.buildSpan("tooBigEventually.cont").asChildOf(tooBigEventually).start()
+      def cscope = tracer.scopeManager().activate(cont)
+      ((ContinuableScope) cscope).setAsyncPropagation(true)
+      def continuation = ((ContinuableScope) cscope).capture()
+      continuation.activate().close() // causes partial write
+    }
+
+    assert writer.size() == 1 // partial write didn't actually happen
+
+    // Then close the trace which causes a (capped) write
+    tooBigEventually.finish()
+    assert writer.size() == 1 // partial write didn't actually happen
+
+
+    expect:
+    Config.DEFAULT_MAX_SPANS_PER_TRACE > Config.DEFAULT_PARTIAL_FLUSH_MIN_SPANS
+    writer.size() == 1 // only 1 partial write happened, second partial and final regular did not
+
+    cleanup:
+    tracer.close()
   }
 
 }


### PR DESCRIPTION
This limits the writing of traces with more spans than the configured max.
Everything else about spans (propagation, id chains, etc.) still works;
only "at the last minute" do we drop the span before putting on the wire
to the upstream trace receiver.  2000 as the default was chosen somewhat
arbitrarily.