### PR TITLE
Make maxSpansPerTrace optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ content](https://docs.signalfx.com/en/latest/apm/apm-overview/apm-metadata.html)
 | `signalfx.db.statement.max.length` | `SIGNALFX_DB_STATEMENT_MAX_LENGTH` | `1024` | The maximum number of characters written for the OpenTracing `db.statement` tag. |
 | `signalfx.recorded.value.max.length` | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `12288` | The maximum number of characters for any Zipkin-encoded tagged or logged value. |
 | `signalfx.trace.annotated.method.blacklist` | `SIGNALFX_TRACE_ANNOTATED_METHOD_BLACKLIST` | `null` | Prevent `@Trace` annotation functionality for the target method string of format `package.OuterClass[methodOne,methodTwo];other.package.OuterClass$InnerClass[*];` (`;` is required and `*` for all methods in class). |
-| `signalfx.max.spans.per.trace` | `SIGNALFX_MAX_SPANS_PER_TRACE` | `2000` | Drop (don't deliver) traces with more spans than this. Intended to prevent runaway traces from flooding upstream systems. |
+| `signalfx.max.spans.per.trace` | `SIGNALFX_MAX_SPANS_PER_TRACE` | `0 (no limit)` | Drop (don't deliver) traces with more spans than this. Intended to prevent runaway traces from flooding upstream systems. |
 
 **Note: System property values take priority over corresponding environment
 variables.**

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -118,7 +118,7 @@ public class Config {
   public static final String LANGUAGE_TAG_VALUE = "jvm";
 
   public static final String MAX_SPANS_PER_TRACE = "max.spans.per.trace";
-  public static final Integer DEFAULT_MAX_SPANS_PER_TRACE = 2000;
+  public static final Integer DEFAULT_MAX_SPANS_PER_TRACE = 0;
 
   public static final String DEFAULT_SERVICE_NAME = "unnamed-java-app";
 

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -93,6 +93,8 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
   private final HttpCodec.Injector injector;
   private final HttpCodec.Extractor extractor;
 
+  @Getter private final int maxSpansPerTrace;
+
   /** By default, report to local agent and collect all traces. */
   public DDTracer() {
     this(Config.get());
@@ -217,6 +219,28 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
       final Map<String, String> serviceNameMappings,
       final Map<String, String> taggedHeaders,
       final int partialFlushMinSpans) {
+    this(
+        serviceName,
+        writer,
+        sampler,
+        localRootSpanTags,
+        defaultSpanTags,
+        serviceNameMappings,
+        taggedHeaders,
+        partialFlushMinSpans,
+        Config.DEFAULT_MAX_SPANS_PER_TRACE);
+  }
+
+  public DDTracer(
+      final String serviceName,
+      final Writer writer,
+      final Sampler sampler,
+      final Map<String, String> localRootSpanTags,
+      final Map<String, String> defaultSpanTags,
+      final Map<String, String> serviceNameMappings,
+      final Map<String, String> taggedHeaders,
+      final int partialFlushMinSpans,
+      final int maxSpansPerTrace) {
     assert localRootSpanTags != null;
     assert defaultSpanTags != null;
     assert serviceNameMappings != null;
@@ -230,6 +254,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
     this.defaultSpanTags = defaultSpanTags;
     this.serviceNameMappings = serviceNameMappings;
     this.partialFlushMinSpans = partialFlushMinSpans;
+    this.maxSpansPerTrace = maxSpansPerTrace;
 
     shutdownCallback = new ShutdownHook(this);
     try {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -126,7 +126,8 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
         config.getMergedSpanTags(),
         config.getServiceMapping(),
         config.getHeaderTags(),
-        config.getPartialFlushMinSpans());
+        config.getPartialFlushMinSpans(),
+        config.getMaxSpansPerTrace());
     log.debug("Using config: {}", config);
   }
 
@@ -160,7 +161,8 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
         config.getMergedSpanTags(),
         config.getServiceMapping(),
         config.getHeaderTags(),
-        config.getPartialFlushMinSpans());
+        config.getPartialFlushMinSpans(),
+        config.getMaxSpansPerTrace());
   }
 
   /**
@@ -184,7 +186,8 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
         defaultSpanTags,
         serviceNameMappings,
         taggedHeaders,
-        Config.get().getPartialFlushMinSpans());
+        Config.get().getPartialFlushMinSpans(),
+        Config.get().getMaxSpansPerTrace());
   }
 
   /**
@@ -207,7 +210,8 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
         defaultSpanTags,
         serviceNameMappings,
         taggedHeaders,
-        Config.get().getPartialFlushMinSpans());
+        Config.get().getPartialFlushMinSpans(),
+        Config.get().getMaxSpansPerTrace());
   }
 
   public DDTracer(
@@ -228,7 +232,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
         serviceNameMappings,
         taggedHeaders,
         partialFlushMinSpans,
-        Config.DEFAULT_MAX_SPANS_PER_TRACE);
+        Config.get().getMaxSpansPerTrace());
   }
 
   public DDTracer(


### PR DESCRIPTION
Set a default value of 0 (meaning "no limit"), add test ensuring that the default is in fact no limit.