### PR TITLE
ErrorAnalyzer: change names/values for error tags

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -54,9 +54,10 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object, 
         "$Tags.COMPONENT" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
-          "error.msg" { it == null || it == EXCEPTION.body }
-          "error.type" { it == null || it == Exception.name }
-          "error.stack" { it == null || it instanceof String }
+          "sfx.error.message" { it == null || it == EXCEPTION.body }
+          "sfx.error.object" { it == null || it == Exception.name }
+          "sfx.error.kind" { it == null || it instanceof String }
+          "sfx.error.stack" { it == null || it instanceof String }
         }
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"

--- a/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
+++ b/dd-java-agent/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
@@ -108,9 +108,10 @@ class GlassFishServerTest extends HttpServerTest<GlassFish, Servlet3Decorator> {
         "$Tags.COMPONENT" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
-          "error.msg" { it == null || it == EXCEPTION.body }
-          "error.type" { it == null || it == Exception.name }
-          "error.stack" { it == null || it instanceof String }
+          "sfx.error.message" { it == null || it == EXCEPTION.body }
+          "sfx.error.object" { it == null || it == Exception.name }
+          "sfx.error.kind" { it == null || it instanceof String }
+          "sfx.error.stack" { it == null || it instanceof String }
         }
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -214,8 +214,9 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
             "$Tags.HTTP_METHOD" "GET"
             if (error) {
               tag('error', true)
-              tag('error.stack', String)
-              tag('error.type', errorType)
+              tag('sfx.error.stack', String)
+              tag('sfx.error.kind', String)
+              tag('sfx.error.object', errorType)
             }
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/DropwizardTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/DropwizardTest.groovy
@@ -117,9 +117,10 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport, Servlet3Decor
         "$Tags.COMPONENT.key" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR.key" endpoint.errored
-          "error.msg" { it == null || it == EXCEPTION.body }
-          "error.type" { it == null || it == Exception.name }
-          "error.stack" { it == null || it instanceof String }
+          "sfx.error.messasge" { it == null || it == EXCEPTION.body }
+          "sfx.error.object" { it == null || it == Exception.name }
+          "sfx.error.kind" { it == null || it instanceof String }
+          "sfx.error.stack" { it == null || it instanceof String }
         }
         "$Tags.HTTP_STATUS.key" endpoint.status
         "$Tags.HTTP_URL.key" "${endpoint.resolve(address)}"

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -213,8 +213,9 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
             "$Tags.HTTP_METHOD" "GET"
             if (error) {
               tag('error', true)
-              tag('error.stack', String)
-              tag('error.type', errorType)
+              tag('sfx.error.stack', String)
+              tag('sfx.error.kind', String)
+              tag('sfx.error.object', errorType)
             }
             defaultTags()
           }

--- a/dd-java-agent/instrumentation/jersey/src/test/groovy/JerseyInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jersey/src/test/groovy/JerseyInstrumentationTest.groovy
@@ -99,9 +99,10 @@ class JerseyInstrumentationTest extends AgentTestRunner {
             "$Tags.COMPONENT.key" "jersey"
             // Raised exception varies by version so don't use TagsAssert helpers
             "error" true
-            "error.type" String
-            "error.stack" String
-            "error.msg" String
+            "sfx.error.object" String
+            "sfx.error.kind" String
+            "sfx.error.stack" String
+            "sfx.error.message" String
           }
         }
       }

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -130,9 +130,10 @@ class JettyHandlerTest extends HttpServerTest<Server, JettyDecorator> {
         "$Tags.COMPONENT" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
-          "error.msg" { it == null || it == EXCEPTION.body }
-          "error.type" { it == null || it == Exception.name }
-          "error.stack" { it == null || it instanceof String }
+          "sfx.error.message" { it == null || it == EXCEPTION.body }
+          "sfx.error.object" { it == null || it == Exception.name }
+          "sfx.error.kind" { it == null || it instanceof String }
+          "sfx.error.stack" { it == null || it instanceof String }
         }
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -320,13 +320,14 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "servlet.context" "/$jspWebappContext"
             "http.status_code" 500
             "error" true
-            "error.type" { String tagExceptionType ->
+            "sfx.error.object" { String tagExceptionType ->
               return tagExceptionType == exceptionClass.getName() || tagExceptionType.contains(exceptionClass.getSimpleName())
             }
-            "error.msg" { String tagErrorMsg ->
+            "sfx.error.message" { String tagErrorMsg ->
               return errorMessageOptional || tagErrorMsg instanceof String
             }
-            "error.stack" String
+            "sfx.error.stack" String
+            "sfx.error.kind" String
             defaultTags()
           }
         }
@@ -342,13 +343,14 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
             "error" true
-            "error.type" { String tagExceptionType ->
+            "sfx.error.object" { String tagExceptionType ->
               return tagExceptionType == exceptionClass.getName() || tagExceptionType.contains(exceptionClass.getSimpleName())
             }
-            "error.msg" { String tagErrorMsg ->
+            "sfx.error.message" { String tagErrorMsg ->
               return errorMessageOptional || tagErrorMsg instanceof String
             }
-            "error.stack" String
+            "sfx.error.stack" String
+            "sfx.error.kind" String
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import com.google.common.io.Files
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -124,9 +124,10 @@ class PlayServerTest extends HttpServerTest<Server, AkkaHttpServerDecorator> {
         "$Tags.COMPONENT" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
-          "error.msg" { it == null || it == EXCEPTION.body }
-          "error.type" { it == null || it == Exception.name }
-          "error.stack" { it == null || it instanceof String }
+          "sfx.error.message" { it == null || it == EXCEPTION.body }
+          "sfx.error.object" { it == null || it == Exception.name }
+          "sfx.error.kind" { it == null || it instanceof String }
+          "sfx.error.stack" { it == null || it instanceof String }
         }
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -101,9 +101,10 @@ class JettyServlet2Test extends HttpServerTest<Server, Servlet2Decorator> {
         "$Tags.COMPONENT" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
-          "error.msg" { it == null || it == EXCEPTION.body }
-          "error.type" { it == null || it == Exception.name }
-          "error.stack" { it == null || it instanceof String }
+          "sfx.error.message" { it == null || it == EXCEPTION.body }
+          "sfx.error.kind" { it == null || it == Exception.name }
+          "sfx.error.kind" { it == null || it instanceof String }
+          "sfx.error.stack" { it == null || it instanceof String }
         }
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -102,7 +102,7 @@ class JettyServlet2Test extends HttpServerTest<Server, Servlet2Decorator> {
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
           "sfx.error.message" { it == null || it == EXCEPTION.body }
-          "sfx.error.kind" { it == null || it == Exception.name }
+          "sfx.error.object" { it == null || it == Exception.name }
           "sfx.error.kind" { it == null || it instanceof String }
           "sfx.error.stack" { it == null || it instanceof String }
         }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -90,9 +90,10 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
         "$Tags.COMPONENT" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
-          "error.msg" { it == null || it == EXCEPTION.body }
-          "error.type" { it == null || it == Exception.name }
-          "error.stack" { it == null || it instanceof String }
+          "sfx.error.message" { it == null || it == EXCEPTION.body }
+          "sfx.error.object" { it == null || it == Exception.name }
+          "sfx.error.kind" { it == null || it instanceof String }
+          "sfx.error.stack" { it == null || it instanceof String }
         }
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -254,9 +254,10 @@ abstract class JettyDispatchTest extends JettyServlet3Test {
             "$Tags.COMPONENT" serverDecorator.component()
             if (endpoint.errored) {
               "$Tags.ERROR" endpoint.errored
-              "error.msg" { it == null || it == EXCEPTION.body }
-              "error.type" { it == null || it == Exception.name }
-              "error.stack" { it == null || it instanceof String }
+              "sfx.error.message" { it == null || it == EXCEPTION.body }
+              "sfx.error.object" { it == null || it == Exception.name }
+              "sfx.error.kind" { it == null || it instanceof String }
+              "sfx.error.stack" { it == null || it instanceof String }
             }
             "$Tags.HTTP_STATUS" endpoint.status
             "$Tags.HTTP_URL" "${endpoint.resolve(address)}"

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -306,9 +306,10 @@ abstract class TomcatDispatchTest extends TomcatServlet3Test {
             "$Tags.COMPONENT" serverDecorator.component()
             if (endpoint.errored) {
               "$Tags.ERROR" endpoint.errored
-              "error.msg" { it == null || it == EXCEPTION.body }
-              "error.type" { it == null || it == Exception.name }
-              "error.stack" { it == null || it instanceof String }
+              "sfx.error.message" { it == null || it == EXCEPTION.body }
+              "sfx.error.object" { it == null || it == Exception.name }
+              "sfx.error.kind" { it == null || it instanceof String }
+              "sfx.error.stack" { it == null || it instanceof String }
             }
             "$Tags.HTTP_STATUS" endpoint.status
             "$Tags.HTTP_URL" "${endpoint.resolve(address)}"

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -132,9 +132,10 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext,
         "$Tags.COMPONENT" serverDecorator.component()
         if (endpoint.errored) {
           "$Tags.ERROR" endpoint.errored
-          "error.msg" { it == null || it == EXCEPTION.body }
-          "error.type" { it == null || it == Exception.name }
-          "error.stack" { it == null || it instanceof String }
+          "sfx.error.message" { it == null || it == EXCEPTION.body }
+          "sfx.error.object" { it == null || it == Exception.name }
+          "sfx.error.kind" { it == null || it instanceof String }
+          "sfx.error.stack" { it == null || it instanceof String }
         }
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -54,11 +54,12 @@ class TagsAssert {
 
   def errorTags(Class<Throwable> errorType, message) {
     tag("error", true)
-    tag("error.type", errorType.name)
-    tag("error.stack", String)
+    tag("sfx.error.object", errorType.name)
+    tag("sfx.error.stack", String)
+    tag("sfx.error.kind", String)
 
     if (message != null) {
-      tag("error.msg", message)
+      tag("sfx.error.message", message)
     }
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -15,9 +15,9 @@ public class DDTags {
   public static final String USER_NAME = "user.principal";
   public static final String ENTITY_NAME = "entity.name";
 
-  public static final String ERROR_MSG = "error.msg"; // string representing the error message
-  public static final String ERROR_TYPE = "error.type"; // string representing the type of the error
-  public static final String ERROR_STACK = "error.stack"; // human readable version of the stack
+  public static final String ERROR_MSG = "sfx.error.message"; // string representing the error message
+  public static final String ERROR_TYPE = "sfx.error.object"; // string representing the type of the error
+  public static final String ERROR_STACK = "sfx.error.stack"; // human readable version of the stack
 
   public static final String ANALYTICS_SAMPLE_RATE = "_dd1.sr.eausr";
   @Deprecated public static final String EVENT_SAMPLE_RATE = ANALYTICS_SAMPLE_RATE;

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -15,8 +15,10 @@ public class DDTags {
   public static final String USER_NAME = "user.principal";
   public static final String ENTITY_NAME = "entity.name";
 
-  public static final String ERROR_MSG = "sfx.error.message"; // string representing the error message
-  public static final String ERROR_TYPE = "sfx.error.object"; // string representing the type of the error
+  public static final String ERROR_MSG =
+      "sfx.error.message"; // string representing the error message
+  public static final String ERROR_TYPE =
+      "sfx.error.object"; // string representing the type of the error
   public static final String ERROR_STACK = "sfx.error.stack"; // human readable version of the stack
 
   public static final String ANALYTICS_SAMPLE_RATE = "_dd1.sr.eausr";

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
@@ -155,7 +155,7 @@ public class DDSpan implements Span, MutableSpan {
     final String type = error.getClass().getName();
     setTag(DDTags.ERROR_MSG, error.getMessage());
     setTag(DDTags.ERROR_TYPE, error.getClass().getName());
-    setTag("sfx.error.kind", type.contains(".") ? type.substring(type.lastIndexOf(".")+1) : type);
+    setTag("sfx.error.kind", type.contains(".") ? type.substring(type.lastIndexOf(".") + 1) : type);
 
     final StringWriter errorString = new StringWriter();
     error.printStackTrace(new PrintWriter(errorString));

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
@@ -152,8 +152,10 @@ public class DDSpan implements Span, MutableSpan {
   public void setErrorMeta(final Throwable error) {
     setError(true);
 
+    final String type = error.getClass().getName();
     setTag(DDTags.ERROR_MSG, error.getMessage());
     setTag(DDTags.ERROR_TYPE, error.getClass().getName());
+    setTag("sfx.error.kind", type.contains(".") ? type.substring(type.lastIndexOf(".")+1) : type);
 
     final StringWriter errorString = new StringWriter();
     error.printStackTrace(new PrintWriter(errorString));

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
@@ -154,7 +154,7 @@ public class DDSpan implements Span, MutableSpan {
 
     final String type = error.getClass().getName();
     setTag(DDTags.ERROR_MSG, error.getMessage());
-    setTag(DDTags.ERROR_TYPE, error.getClass().getName());
+    setTag(DDTags.ERROR_TYPE, type);
     setTag("sfx.error.kind", type.contains(".") ? type.substring(type.lastIndexOf(".") + 1) : type);
 
     final StringWriter errorString = new StringWriter();


### PR DESCRIPTION
- Don't emit error.msg, error.type or error.stack tags
- Do emit sfx.error.{message, object, kind, stack} tags, with values appropriate to the OpenTracing semantic conventions at https://github.com/opentracing/specification/blob/master/semantic_conventions.md#log-fields-table
- Fix up tests accordingly