### PR TITLE
Support for Vert.x RxJava

### DIFF
--- a/dd-java-agent/instrumentation/vertx/src/main/java/datadog/trace/instrumentation/vertx/VertxRxInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx/src/main/java/datadog/trace/instrumentation/vertx/VertxRxInstrumentation.java
@@ -1,0 +1,50 @@
+// Modified by SignalFx
+package datadog.trace.instrumentation.vertx;
+
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isStatic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import java.util.HashMap;
+import java.util.Map;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class VertxRxInstrumentation extends Instrumenter.Default {
+
+  public VertxRxInstrumentation() {
+    super("vertx", "vert.x");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+
+    return not(isInterface()).and(named("io.vertx.reactivex.impl.AsyncResultSingle"));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".AsyncResultSingleAdvice", packageName + ".AsyncResultHandlerConsumerWrapper"
+    };
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    final Map adviceMap = new HashMap();
+    adviceMap.put(
+        isMethod()
+            .and(isStatic())
+            .and(named("toSingle"))
+            .and(takesArgument(0, named("java.util.function.Consumer"))),
+        packageName + ".AsyncResultSingleAdvice");
+    return adviceMap;
+  }
+}

--- a/dd-java-agent/instrumentation/vertx/src/main/java/datadog/trace/instrumentation/vertx/VertxRxInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx/src/main/java/datadog/trace/instrumentation/vertx/VertxRxInstrumentation.java
@@ -1,6 +1,7 @@
 // Modified by SignalFx
 package datadog.trace.instrumentation.vertx;
 
+import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
@@ -10,7 +11,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -38,13 +38,11 @@ public class VertxRxInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    final Map adviceMap = new HashMap();
-    adviceMap.put(
+    return singletonMap(
         isMethod()
             .and(isStatic())
             .and(named("toSingle"))
             .and(takesArgument(0, named("java.util.function.Consumer"))),
         packageName + ".AsyncResultSingleAdvice");
-    return adviceMap;
   }
 }

--- a/dd-java-agent/instrumentation/vertx/src/main/java8/datadog/trace/instrumentation/vertx/AsyncResultHandlerConsumerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx/src/main/java8/datadog/trace/instrumentation/vertx/AsyncResultHandlerConsumerWrapper.java
@@ -1,0 +1,43 @@
+// Modified by SignalFx
+package datadog.trace.instrumentation.vertx;
+
+import static datadog.trace.instrumentation.api.AgentTracer.propagate;
+
+import datadog.trace.context.TraceScope;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AsyncResultHandlerConsumerWrapper implements Consumer<Handler<AsyncResult>> {
+
+  private final Consumer<Handler<AsyncResult>> delegate;
+  private final TraceScope.Continuation continuation;
+
+  public AsyncResultHandlerConsumerWrapper(final Consumer<Handler<AsyncResult>> delegate) {
+    this.delegate = delegate;
+    continuation = propagate().capture();
+  }
+
+  @Override
+  public void accept(final Handler<AsyncResult> asyncResultHandler) {
+    if (continuation != null) {
+      try (final TraceScope scope = continuation.activate()) {
+        scope.setAsyncPropagation(true);
+        delegate.accept(asyncResultHandler);
+      }
+    } else {
+      delegate.accept(asyncResultHandler);
+    }
+  }
+
+  public static Consumer<Handler<AsyncResult>> wrapIfNeeded(
+      final Consumer<Handler<AsyncResult>> delegate) {
+    if (!(delegate instanceof AsyncResultHandlerConsumerWrapper)) {
+      log.debug("Wrapping consumer {}", delegate);
+      return new AsyncResultHandlerConsumerWrapper(delegate);
+    }
+    return delegate;
+  }
+}

--- a/dd-java-agent/instrumentation/vertx/src/main/java8/datadog/trace/instrumentation/vertx/AsyncResultSingleAdvice.java
+++ b/dd-java-agent/instrumentation/vertx/src/main/java8/datadog/trace/instrumentation/vertx/AsyncResultSingleAdvice.java
@@ -1,0 +1,17 @@
+// Modified by SignalFx
+package datadog.trace.instrumentation.vertx;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import java.util.function.Consumer;
+import net.bytebuddy.asm.Advice;
+
+public class AsyncResultSingleAdvice {
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static void wrapConsumer(
+      @Advice.Argument(value = 0, readOnly = false) Consumer<Handler<AsyncResult>> consumer) {
+
+    consumer = AsyncResultHandlerConsumerWrapper.wrapIfNeeded(consumer);
+  }
+}

--- a/dd-java-agent/instrumentation/vertx/src/rxHandlerTests/groovy/VertxRxServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/rxHandlerTests/groovy/VertxRxServerTest.groovy
@@ -1,0 +1,119 @@
+// Modified by SignalFx
+
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.agent.test.utils.PortUtils
+import io.vertx.reactivex.core.Vertx
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import spock.lang.Shared
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+
+class VertxRxServerTest extends AgentTestRunner {
+  static {
+    System.setProperty("dd.integration.jdbc.enabled", "true")
+  }
+
+  @Shared
+  OkHttpClient client = OkHttpUtils.client()
+
+  @Shared
+  int port
+
+  @Shared
+  Vertx server
+
+  def setupSpec() {
+    port = PortUtils.randomOpenPort()
+    server = VertxRxWebTestServer.start(port)
+  }
+
+  def cleanupSpec() {
+    server.close()
+  }
+
+  def "test #responseCode response handling"() {
+    setup:
+    def request = new Request.Builder().url("http://localhost:$port$path").get().build()
+    def response = client.newCall(request).execute()
+
+    expect:
+    response.code() == responseCode
+
+    and:
+    assertTraces(1) {
+      trace(0, 5) {
+        spanByOperationName("netty.request") {
+          spanType "web"
+        }
+        spanByOperationName("io.vertx.core.http.impl.WebSocketRequestHandler.handle") {
+          childOf spanByOperationName("netty.request")
+        }
+        spanByOperationName("io.vertx.reactivex.core.http.HttpServer.handle") {
+          childOf spanByOperationName("io.vertx.core.http.impl.WebSocketRequestHandler.handle")
+        }
+        spanByOperationName("io.vertx.ext.web.impl.RouterImpl.handle") {
+          childOf spanByOperationName("io.vertx.reactivex.core.http.HttpServer.handle")
+        }
+        spanByOperationName("io.vertx.reactivex.ext.web.Route.handle") {
+          childOf spanByOperationName("io.vertx.ext.web.impl.RouterImpl.handle")
+        }
+      }
+    }
+
+    where:
+    responseCode   | path
+    SUCCESS.status | SUCCESS.path
+  }
+
+  def "test causality for jdbc rx"() {
+    setup:
+    def request = new Request.Builder().url("http://localhost:$port$path").get().build()
+    def response = client.newCall(request).execute()
+
+    expect:
+    response.code() == responseCode
+
+    and:
+    assertTraces(1) {
+      trace(0, 9) {
+        spanByOperationName("netty.request") {
+          spanType "web"
+        }
+        spanByOperationName("io.vertx.core.http.impl.WebSocketRequestHandler.handle") {
+          childOf spanByOperationName("netty.request")
+        }
+        spanByOperationName("io.vertx.reactivex.core.http.HttpServer.handle") {
+          childOf spanByOperationName("io.vertx.core.http.impl.WebSocketRequestHandler.handle")
+        }
+        spanByOperationName("io.vertx.ext.web.impl.RouterImpl.handle") {
+          childOf spanByOperationName("io.vertx.reactivex.core.http.HttpServer.handle")
+        }
+        spanByOperationName("io.vertx.reactivex.ext.web.Route.handle") {
+          childOf spanByOperationName("io.vertx.ext.web.impl.RouterImpl.handle")
+        }
+        spanByOperationName("VertxRxWebTestServer.handleListProducts") {
+          childOf spanByOperationName("io.vertx.reactivex.ext.web.Route.handle")
+        }
+        spanByOperationName("VertxRxWebTestServer.listProducts") {
+          childOf spanByOperationName("VertxRxWebTestServer.handleListProducts")
+        }
+        spanByOperationName("hsqldb.query") {
+          spanType "sql"
+          childOf spanByOperationName("VertxRxWebTestServer.listProducts")
+        }
+        spanByOperationName("database.connection") {
+          childOf spanByOperationName("VertxRxWebTestServer.listProducts")
+        }
+      }
+    }
+
+    where:
+    responseCode   | name            | path            | error
+    SUCCESS.status | "/listProducts" | "/listProducts" | false
+  }
+
+
+}

--- a/dd-java-agent/instrumentation/vertx/src/rxHandlerTests/java/VertxRxWebTestServer.java
+++ b/dd-java-agent/instrumentation/vertx/src/rxHandlerTests/java/VertxRxWebTestServer.java
@@ -1,0 +1,127 @@
+// Modified by SignalFx
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS;
+
+import com.signalfx.tracing.api.Trace;
+import io.reactivex.Single;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.core.AbstractVerticle;
+import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.http.HttpServerResponse;
+import io.vertx.reactivex.ext.jdbc.JDBCClient;
+import io.vertx.reactivex.ext.sql.SQLConnection;
+import io.vertx.reactivex.ext.web.Router;
+import io.vertx.reactivex.ext.web.RoutingContext;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+public class VertxRxWebTestServer extends AbstractVerticle {
+  private static final String CONFIG_HTTP_SERVER_PORT = "http.server.port";
+  private static JDBCClient client;
+
+  public static Vertx start(final int port) throws ExecutionException, InterruptedException {
+    /* This is highly against Vertx ideas, but our tests are synchronous
+    so we have to make sure server is up and running */
+    final CompletableFuture<Void> future = new CompletableFuture<>();
+
+    final Vertx server = Vertx.vertx(new VertxOptions());
+
+    client =
+        JDBCClient.createShared(
+            server,
+            new JsonObject()
+                .put("url", "jdbc:hsqldb:mem:test?shutdown=true")
+                .put("driver_class", "org.hsqldb.jdbcDriver"));
+
+    server.deployVerticle(
+        VertxRxWebTestServer.class.getName(),
+        new DeploymentOptions().setConfig(new JsonObject().put(CONFIG_HTTP_SERVER_PORT, port)),
+        res -> {
+          if (!res.succeeded()) {
+            final RuntimeException exception =
+                new RuntimeException("Cannot deploy server Verticle", res.cause());
+            future.completeExceptionally(exception);
+          }
+          future.complete(null);
+        });
+    // block until vertx server is up
+    future.get();
+
+    return server;
+  }
+
+  @Override
+  public void start(final Future<Void> startFuture) {
+    setUpInitialData(
+        ready -> {
+          final Router router = Router.router(vertx);
+          final int port = config().getInteger(CONFIG_HTTP_SERVER_PORT);
+          router
+              .route(SUCCESS.getPath())
+              .handler(
+                  ctx -> ctx.response().setStatusCode(SUCCESS.getStatus()).end(SUCCESS.getBody()));
+
+          router.route("/listProducts").handler(this::handleListProducts);
+
+          vertx
+              .createHttpServer()
+              .requestHandler(router::accept)
+              .listen(port, h -> startFuture.complete());
+        });
+  }
+
+  @Trace
+  private void handleListProducts(final RoutingContext routingContext) {
+    final HttpServerResponse response = routingContext.response();
+    final Single<JsonArray> jsonArraySingle = listProducts();
+
+    jsonArraySingle.subscribe(
+        arr -> response.putHeader("content-type", "application/json").end(arr.encode()));
+  }
+
+  @Trace
+  private Single<JsonArray> listProducts() {
+    return client
+        .rxQuery("SELECT id, name, price, weight FROM products")
+        .flatMap(
+            result -> {
+              final JsonArray arr = new JsonArray();
+              result.getRows().forEach(arr::add);
+              return Single.just(arr);
+            });
+  }
+
+  private void setUpInitialData(final Handler<Void> done) {
+    client.getConnection(
+        res -> {
+          if (res.failed()) {
+            throw new RuntimeException(res.cause());
+          }
+
+          final SQLConnection conn = res.result();
+
+          conn.execute(
+              "CREATE TABLE IF NOT EXISTS products(id INT IDENTITY, name VARCHAR(255), price FLOAT, weight INT)",
+              ddl -> {
+                if (ddl.failed()) {
+                  throw new RuntimeException(ddl.cause());
+                }
+
+                conn.execute(
+                    "INSERT INTO products (name, price, weight) VALUES ('Egg Whisk', 3.99, 150), ('Tea Cosy', 5.99, 100), ('Spatula', 1.00, 80)",
+                    fixtures -> {
+                      if (fixtures.failed()) {
+                        throw new RuntimeException(fixtures.cause());
+                      }
+
+                      done.handle(null);
+                    });
+              });
+        });
+  }
+}

--- a/dd-java-agent/instrumentation/vertx/vertx.gradle
+++ b/dd-java-agent/instrumentation/vertx/vertx.gradle
@@ -60,7 +60,7 @@ dependencies {
   handlerTestCompile group: 'io.vertx', name: 'vertx-core', version: '3.1.0'
   handlerTestCompile group: 'io.vertx', name: 'vertx-web', version: '3.0.0'
 
-  rxHandlerTestCompile project(':dd-java-agent:instrumentation:netty-4.0')
+  rxHandlerTestCompile project(':dd-java-agent:instrumentation:netty-4.1')
   rxHandlerTestCompile project(':dd-java-agent:instrumentation:jdbc')
   rxHandlerTestCompile group: 'io.vertx', name: 'vertx-core', version: '3.6.0'
   rxHandlerTestCompile group: 'io.vertx', name: 'vertx-web', version: '3.6.0'

--- a/dd-java-agent/instrumentation/vertx/vertx.gradle
+++ b/dd-java-agent/instrumentation/vertx/vertx.gradle
@@ -23,6 +23,10 @@ testSets {
     dirName = 'handlerTests'
   }
 
+  rxHandlerTest {
+    dirName = 'rxHandlerTests'
+  }
+
   v35HandlerTest {
     dirName = 'handlerTests'
   }
@@ -56,6 +60,14 @@ dependencies {
   handlerTestCompile group: 'io.vertx', name: 'vertx-core', version: '3.1.0'
   handlerTestCompile group: 'io.vertx', name: 'vertx-web', version: '3.0.0'
 
+  rxHandlerTestCompile project(':dd-java-agent:instrumentation:netty-4.0')
+  rxHandlerTestCompile project(':dd-java-agent:instrumentation:jdbc')
+  rxHandlerTestCompile group: 'io.vertx', name: 'vertx-core', version: '3.6.0'
+  rxHandlerTestCompile group: 'io.vertx', name: 'vertx-web', version: '3.6.0'
+  rxHandlerTestCompile group: 'io.vertx', name: 'vertx-rx-java2', version: '3.6.0'
+  rxHandlerTestCompile group: 'io.vertx', name: 'vertx-jdbc-client', version: '3.6.0'
+  rxHandlerTestCompile 'org.hsqldb:hsqldb:2.3.4'
+
   v35HandlerTestCompile project(':dd-java-agent:instrumentation:netty-4.1')
   v35HandlerTestCompile group: 'io.vertx', name: 'vertx-core', version: '3.5.0'
   v35HandlerTestCompile group: 'io.vertx', name: 'vertx-web', version: '3.5.0'
@@ -63,4 +75,4 @@ dependencies {
   latestDepTestCompile group: 'io.vertx', name: 'vertx-core', version: '3.+'
 }
 
-test.dependsOn(handlerTest, v35HandlerTest)
+test.dependsOn(handlerTest, v35HandlerTest, rxHandlerTest)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TraceAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TraceAssert.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx 
 package datadog.trace.agent.test.asserts
 
 import datadog.opentracing.DDSpan
@@ -32,6 +33,10 @@ class TraceAssert {
     trace.get(index)
   }
 
+  DDSpan spanByOperationName(String operationName) {
+    span(spanIndexByOperationName(operationName))
+  }
+
   void span(int index, @ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.SpanAssert']) @DelegatesTo(value = SpanAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
     if (index >= size) {
       throw new ArrayIndexOutOfBoundsException(index)
@@ -43,7 +48,15 @@ class TraceAssert {
     assertSpan(trace.get(index), spec)
   }
 
+  void spanByOperationName(String operationName, @ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.SpanAssert']) @DelegatesTo(value = SpanAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
+    span(spanIndexByOperationName(operationName), spec)
+  }
+
   void assertSpansAllVerified() {
     assert assertedIndexes.size() == size
+  }
+
+  private int spanIndexByOperationName(String operationName) {
+    trace.findIndexOf { it.operationName == operationName }
   }
 }

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -131,6 +131,28 @@ class AgentTestRunnerTest extends AgentTestRunner {
     }
   }
 
+  def "test unblocked by completed span using findByOperationName"() {
+    setup:
+    runUnderTrace("parent") {
+      runUnderTrace("child") {}
+      blockUntilChildSpansFinished(1)
+    }
+
+    expect:
+    assertTraces(1) {
+      trace(0, 2) {
+        spanByOperationName("parent") {
+          operationName "parent"
+          parent()
+        }
+        spanByOperationName("child") {
+          operationName "child"
+          childOf(span(0))
+        }
+      }
+    }
+  }
+
   private static getAgentTransformer() {
     Field f
     try {


### PR DESCRIPTION
Added instrumentation for AsyncResultSingle. This fixes the issue with reactive handlers causality. 