### PR TITLE
Jackson streaming and ID performance tweaks

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Ids.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Ids.java
@@ -5,22 +5,16 @@ import java.math.BigInteger;
 
 /** Conversions between DataDog numeric ids and Zipkin hex ids. Supports both 64 and 128 bit ids. */
 public class Ids {
-  private static final String ID_8_BYTES = "%016x";
-  private static final String ID_16_BYTES = "%032x";
-
-  // Anything bigger than this will require more than 16 hex digits to represent
-  private static final BigInteger BIGINT_UNSIGNED_LONG_MAX =
-      BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(2)).add(BigInteger.ONE);
+  private static char[] pad = "00000000000000000000000000000000".toCharArray();
 
   public static String idToHex(String id) {
-    BigInteger asInt = new BigInteger(id, 10);
-
-    String formatStr = ID_8_BYTES;
-    if (asInt.compareTo(BIGINT_UNSIGNED_LONG_MAX) > 0) {
-      formatStr = ID_16_BYTES;
-    }
-
-    return String.format(formatStr, asInt);
+    final String asHex = new BigInteger(id, 10).toString(16);
+    final int desiredLength = asHex.length() > 16 ? 32 : 16;
+    final int padLength = desiredLength - asHex.length();
+    StringBuilder sb = new StringBuilder(desiredLength);
+    sb.insert(0, pad, 0, padLength);
+    sb.insert(padLength, asHex);
+    return sb.toString();
   }
 
   /** The inverse of idToHex. Returns a string that is used as an id in DDSpan. */

--- a/dd-trace-api/src/main/java/datadog/trace/api/Ids.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Ids.java
@@ -3,18 +3,22 @@ package datadog.trace.api;
 
 import java.math.BigInteger;
 
-/** Conversions between DataDog numeric ids and Zipkin hex ids. Supports both 64 and 128 bit ids. */
+/** Conversions between DataDog decimal ids and Zipkin hex ids. Supports both 64 and 128 bit ids. */
 public class Ids {
   private static char[] pad = "00000000000000000000000000000000".toCharArray();
 
-  public static String idToHex(String id) {
+  public static char[] idToHexChars(final String id) {
     final String asHex = new BigInteger(id, 10).toString(16);
     final int desiredLength = asHex.length() > 16 ? 32 : 16;
     final int padLength = desiredLength - asHex.length();
-    StringBuilder sb = new StringBuilder(desiredLength);
-    sb.insert(0, pad, 0, padLength);
-    sb.insert(padLength, asHex);
-    return sb.toString();
+    final char[] s = new char[desiredLength];
+    System.arraycopy(pad, 0, s, 0, desiredLength - asHex.length());
+    asHex.getChars(0, asHex.length(), s, desiredLength - asHex.length());
+    return s;
+  }
+
+  public static String idToHex(final String id) {
+    return new String(idToHexChars(id));
   }
 
   /** The inverse of idToHex. Returns a string that is used as an id in DDSpan. */

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/Api.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/Api.java
@@ -1,9 +1,9 @@
 // Modified by SignalFx
 package datadog.trace.common.writer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import datadog.opentracing.DDSpan;
+import java.io.IOException;
 import java.util.List;
 import okhttp3.Response;
 
@@ -11,7 +11,7 @@ import okhttp3.Response;
 public interface Api {
   Response sendTraces(List<List<DDSpan>> traces);
 
-  byte[] serializeTrace(final List<DDSpan> trace) throws JsonProcessingException;
+  byte[] serializeTrace(final List<DDSpan> trace) throws IOException;
 
   Response sendSerializedTraces(
       final int representativeCount, final Integer sizeInBytes, final List<byte[]> traces);

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
@@ -68,7 +68,7 @@ public class ZipkinV2Api implements Api {
 
   @Override
   public byte[] serializeTrace(final List<DDSpan> trace) throws IOException {
-    final ByteArrayOutputStream stream = new ByteArrayOutputStream(trace.size()*128);
+    final ByteArrayOutputStream stream = new ByteArrayOutputStream(trace.size() * 128);
     final JsonGenerator jsonGenerator = JSON_FACTORY.createGenerator(stream, JsonEncoding.UTF8);
 
     jsonGenerator.writeStartArray();

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/ZipkinV2ApiTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/ZipkinV2ApiTest.groovy
@@ -91,7 +91,6 @@ class ZipkinV2ApiTest extends DDSpecification {
                     "resource.name": "fakeResource"],
       "annotations": [["timestamp" : 1000, "value": "{\"event\":\"some event\"}"]],
       "name"     : "fakeOperation",
-      "kind": null,
       "localEndpoint": ["serviceName": "fakeService"],
       "timestamp"    : 1,
     ])]
@@ -106,7 +105,6 @@ class ZipkinV2ApiTest extends DDSpecification {
       "annotations": [],
       "name"     : "fakeOperation",
       "localEndpoint": ["serviceName": "fakeService"],
-      "kind"    : null,
       "timestamp"    : 100,
     ])]
     [[SpanFactory.newSpanOf(100L).setTag("span.kind", "CliEnt").log(1000L, "some event").log(2000L, Collections.singletonMap("another event", 1))]] | [new TreeMap<>([


### PR DESCRIPTION
A few quick localized wins in the performance (particularly in GC thrash) of writing to Zipkin format.