### PR TITLE
Version 0.36.0-sfx5

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -128,7 +128,7 @@ public class Config {
   public static final String TRACING_LIBRARY_KEY = "signalfx.tracing.library";
   public static final String TRACING_LIBRARY_VALUE = "java-tracing";
   public static final String TRACING_VERSION_KEY = "signalfx.tracing.version";
-  public static final String TRACING_VERSION_VALUE = "0.36.0-sfx4";
+  public static final String TRACING_VERSION_VALUE = "0.36.0-sfx5";
   public static final String DEFAULT_GLOBAL_TAGS =
       String.format(
           "%s:%s,%s:%s",

--- a/signalfx-java-tracing.gradle
+++ b/signalfx-java-tracing.gradle
@@ -18,7 +18,7 @@ def isCI = System.getenv("CI") != null
 allprojects {
   group = 'com.signalfx.public'
   // Don't forget to update TRACING_VERSION_VALUE in dd-trace-api/src/main/java/datadog/trace/api/Config.java
-  version = '0.36.0-sfx4'
+  version = '0.36.0-sfx5'
 
   if (isCI) {
     buildDir = "${rootDir}/workspace/${projectDir.path.replace(rootDir.path, '')}/build/"


### PR DESCRIPTION
* Add max.spans.per.trace

* Breaking change: ErrorAnalyzer - adjust error.* names and values to sfx.* variants

* Add max.continuation.depth

* Add support for Vert.x RxJava

* Tweak performance of zipkin encoding

* Support @TraceSetting allowed exceptions in Spring webmvc.

* Normalize sql statements in db.statement