### PR TITLE
Significantly reduce thrash allocations in zipkin encoding

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Ids.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Ids.java
@@ -5,9 +5,31 @@ import java.math.BigInteger;
 
 /** Conversions between DataDog decimal ids and Zipkin hex ids. Supports both 64 and 128 bit ids. */
 public class Ids {
-  private static char[] pad = "00000000000000000000000000000000".toCharArray();
+  private static final char[] pad = "00000000000000000000000000000000".toCharArray();
+  private static final char[] HexChars = {
+    '0', '1', '2', '3',
+    '4', '5', '6', '7',
+    '8', '9', 'a', 'b',
+    'c', 'd', 'e', 'f',
+  };
 
   public static char[] idToHexChars(final String id) {
+    if (id.length() <= 20) {
+      // *likely* (but not definitely) a 64-bit id: try to parse as such
+      try {
+        long val = Long.parseLong(id);
+        char[] answer = new char[16];
+        for (int i = 0; i < 16; i++) {
+          long mask = (0x0FL << (i * 4));
+          long nybble = (val & mask) >> (i * 4);
+
+          answer[15 - i] = HexChars[(int) (nybble & 0xFF)];
+        }
+        return answer;
+      } catch (NumberFormatException thatsFine) {
+        // continue on to using BigInteger below
+      }
+    }
     final String asHex = new BigInteger(id, 10).toString(16);
     final int desiredLength = asHex.length() > 16 ? 32 : 16;
     final int padLength = desiredLength - asHex.length();

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -262,7 +262,7 @@ public class DDAgentWriter implements Writer {
 
   /** This class is intentionally not threadsafe. */
   private class TraceConsumer implements EventHandler<Event<List<DDSpan>>> {
-    private List<byte[]> serializedTraces = new ArrayList<>();
+    private List<Api.SerializedBuffer> serializedTraces = new ArrayList<>();
     private int payloadSize = 0;
 
     @Override
@@ -273,8 +273,8 @@ public class DDAgentWriter implements Writer {
       if (trace != null) {
         traceCount.incrementAndGet();
         try {
-          final byte[] serializedTrace = api.serializeTrace(trace);
-          payloadSize += serializedTrace.length;
+          final Api.SerializedBuffer serializedTrace = api.serializeTrace(trace);
+          payloadSize += serializedTrace.length();
           serializedTraces.add(serializedTrace);
 
           monitor.onSerialize(DDAgentWriter.this, trace, serializedTrace);
@@ -301,7 +301,7 @@ public class DDAgentWriter implements Writer {
           return;
           // scheduleFlush called in finally block.
         }
-        final List<byte[]> toSend = serializedTraces;
+        final List<Api.SerializedBuffer> toSend = serializedTraces;
         serializedTraces = new ArrayList<>(toSend.size());
         // ^ Initialize with similar size to reduce arraycopy churn.
 
@@ -391,7 +391,9 @@ public class DDAgentWriter implements Writer {
     void onScheduleFlush(final DDAgentWriter agentWriter, final boolean previousIncomplete);
 
     void onSerialize(
-        final DDAgentWriter agentWriter, final List<DDSpan> trace, final byte[] serializedTrace);
+        final DDAgentWriter agentWriter,
+        final List<DDSpan> trace,
+        final Api.SerializedBuffer serializedTrace);
 
     void onFailedSerialize(
         final DDAgentWriter agentWriter, final List<DDSpan> trace, final Throwable optionalCause);
@@ -428,7 +430,9 @@ public class DDAgentWriter implements Writer {
 
     @Override
     public void onSerialize(
-        final DDAgentWriter agentWriter, final List<DDSpan> trace, final byte[] serializedTrace) {}
+        final DDAgentWriter agentWriter,
+        final List<DDSpan> trace,
+        final Api.SerializedBuffer serializedTrace) {}
 
     @Override
     public void onFailedSerialize(
@@ -520,10 +524,12 @@ public class DDAgentWriter implements Writer {
 
     @Override
     public void onSerialize(
-        final DDAgentWriter agentWriter, final List<DDSpan> trace, final byte[] serializedTrace) {
+        final DDAgentWriter agentWriter,
+        final List<DDSpan> trace,
+        final Api.SerializedBuffer serializedTrace) {
       // DQH - Because of Java tracer's 2 phase acceptance and serialization scheme, this doesn't
       // map precisely
-      statsd.count("queue.accepted_size", serializedTrace.length);
+      statsd.count("queue.accepted_size", serializedTrace.length());
     }
 
     @Override


### PR DESCRIPTION
* Use a short-circuit for turning 64-bit IDs into hex
* Remove some spurious extra allocations/doubled work
* Rework buffer strategy between serialization and writing to the wire to not double-copy traces.