### PR TITLE
Support vertx.runOnContext

### DIFF
--- a/dd-java-agent/instrumentation/vertx/src/main/java8/datadog/trace/instrumentation/vertx/VertxHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/vertx/src/main/java8/datadog/trace/instrumentation/vertx/VertxHandlerAdvice.java
@@ -30,8 +30,11 @@ public class VertxHandlerAdvice {
 
     final AgentSpan span =
         startSpan(operationName + ".handle")
-        .setTag("handler.type", event.getClass().getName())
         .setTag("component", "vertx");
+
+    if (event != null) {
+      span.setTag("handler.type", event.getClass().getName());
+    }
 
     DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxServerTest.groovy
@@ -354,4 +354,30 @@ class VertxServerTest extends AgentTestRunner {
       }
     }
   }
+
+  def "test runOnContext"() {
+    when:
+    server.runOnContext(new Handler<Void>() {
+      @Override
+      void handle(Void v) {
+        return
+      }
+    })
+
+    then:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          serviceName "unnamed-java-app"
+          operationName "server.VertxServerTest.handle"
+          resourceName "server.VertxServerTest.handle"
+          errored false
+          tags {
+            "$Tags.COMPONENT.key" "vertx"
+            defaultTags(true)
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
The current handler instrumentation assumes the event argument isn't null, which won't be the case for any `Handler<Void>` instances. 