### PR TITLE
Add a read timeout so that misbehaving endpoints don't cause a leak

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
@@ -282,6 +282,7 @@ public class ZipkinV2Api implements Api {
     final HttpURLConnection httpCon;
     final URL url = new URL(endpoint);
     httpCon = (HttpURLConnection) url.openConnection();
+    httpCon.setReadTimeout(30 * 1000);
     httpCon.setDoOutput(true);
     httpCon.setDoInput(true);
     httpCon.setRequestMethod("POST");


### PR DESCRIPTION
Saw a customer where 7 GB of serialized traces were piled up in memory, blocked on one trace batch being written to our endpoint.  The endpoint apparently accepted the connection and the writes but had not responded with an HTTP status yet (ever); other traces were piled up in the queue waiting for this one to finish.  Adding a read timeout breaks the chain and at least allows the agent to not leak memory forever when this happens.