### PR TITLE
Set span.kind=server only for receiving end of a distributed trace

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ServerDecorator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/decorator/ServerDecorator.java
@@ -9,7 +9,11 @@ public abstract class ServerDecorator extends BaseDecorator {
   @Override
   public AgentSpan afterStart(final AgentSpan span) {
     assert span != null;
-    span.setTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
+
+    if (isRootSpan(span)) {
+      span.setTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
+    }
+
     return super.afterStart(span);
   }
 
@@ -19,5 +23,9 @@ public abstract class ServerDecorator extends BaseDecorator {
       return this.afterStart(span);
     }
     return super.afterStart(span);
+  }
+
+  private boolean isRootSpan(final AgentSpan span) {
+    return span.getLocalRootSpan() == span;
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package datadog.trace.agent.decorator
 
 import datadog.trace.agent.test.utils.ConfigUtils

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/decorator/BaseDecoratorTest.groovy
@@ -23,6 +23,7 @@ class BaseDecoratorTest extends DDSpecification {
     1 * span.setTag(DDTags.SPAN_TYPE, decorator.spanType())
     1 * span.setTag(Tags.COMPONENT.key, "test-component")
     _ * span.setTag(_, _) // Want to allow other calls from child implementations.
+    _ * span.getLocalRootSpan() // Want to allow other calls from child implementations.
     0 * _
   }
 

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.instrumentation.api.Tags

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -106,7 +106,6 @@ class GrpcStreamingTest extends AgentTestRunner {
             childOf span(0)
             errored false
             tags {
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
               "$Tags.COMPONENT" "grpc-server"
               "message.type" "example.Helloworld\$Response"
               defaultTags()

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.instrumentation.api.Tags

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -61,7 +61,6 @@ class GrpcTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT" "grpc-server"
             "message.type" "example.Helloworld\$Request"
             defaultTags()
@@ -159,7 +158,6 @@ class GrpcTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT" "grpc-server"
             "message.type" "example.Helloworld\$Request"
             defaultTags()
@@ -245,7 +243,6 @@ class GrpcTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT" "grpc-server"
             "message.type" "example.Helloworld\$Request"
             defaultTags()

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -92,7 +92,6 @@ class PlayServerTest extends HttpServerTest<Server, NettyHttpServerDecorator> {
         "$Tags.HTTP_URL" String
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_METHOD" String
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         defaultTags()
         if (endpoint == ERROR) {
           "$Tags.ERROR" true

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package server
 
 import datadog.opentracing.DDSpan

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -95,7 +95,6 @@ class PlayServerTest extends HttpServerTest<Server, AkkaHttpServerDecorator> {
         "$Tags.HTTP_URL" String
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_METHOD" String
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         defaultTags()
         if (endpoint == ERROR) {
           "$Tags.ERROR" true

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackOtherTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/RatpackOtherTest.groovy
@@ -91,7 +91,6 @@ class RatpackOtherTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.COMPONENT" "ratpack"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
             "$Tags.HTTP_URL" "${app.address.resolve(path)}"

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -113,7 +113,6 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp, NettyHttpServerD
         "$Tags.PEER_PORT" Integer
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_METHOD" String
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         defaultTags()
         if (endpoint == ERROR) {
           "$Tags.ERROR" true

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package server
 
 import datadog.opentracing.DDSpan

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
@@ -63,7 +63,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf(span(1))
           tags {
             "$Tags.COMPONENT" "spring-webflux-controller"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             if (annotatedMethod == null) {
               // Functional API
               "request.predicate" "(GET && $urlPathWithVariables)"
@@ -137,7 +136,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf(span(1))
           tags {
             "$Tags.COMPONENT" "spring-webflux-controller"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             if (annotatedMethod == null) {
               // Functional API
               "request.predicate" "(GET && $urlPathWithVariables)"
@@ -237,7 +235,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "spring-webflux-controller"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "handler.type" "org.springframework.web.reactive.resource.ResourceWebHandler"
             errorTags(ResponseStatusException, String)
             defaultTags()
@@ -269,7 +266,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf(span(1))
           tags {
             "$Tags.COMPONENT" "spring-webflux-controller"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "request.predicate" "(POST && /echo)"
             "handler.type" { String tagVal ->
               return tagVal.contains(EchoHandlerFunction.getName())
@@ -353,7 +349,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           errored true
           tags {
             "$Tags.COMPONENT" "spring-webflux-controller"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             if (annotatedMethod == null) {
               // Functional API
               "request.predicate" "(GET && $urlPathWithVariables)"
@@ -418,7 +413,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$Tags.COMPONENT" "spring-webflux-controller"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "request.predicate" "(GET && /double-greet-redirect)"
             "handler.type" { String tagVal ->
               return (tagVal.contains(INNER_HANDLER_FUNCTION_CLASS_TAG_PREFIX)
@@ -436,7 +430,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf(span(1))
           tags {
             "$Tags.COMPONENT" "spring-webflux-controller"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "request.predicate" "(GET && /double-greet)"
             "handler.type" { String tagVal ->
               return tagVal.contains(INNER_HANDLER_FUNCTION_CLASS_TAG_PREFIX)
@@ -493,7 +486,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             childOf(span(1))
             tags {
               "$Tags.COMPONENT" "spring-webflux-controller"
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
               if (annotatedMethod == null) {
                 // Functional API
                 "request.predicate" "(GET && $urlPathWithVariables)"

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -109,7 +109,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext,
           tags {
             "component" "spring-webmvc"
             "view.type" RedirectView.name
-            "span.kind" "server"
             defaultTags()
           }
         }
@@ -133,7 +132,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext,
       childOf(parent as DDSpan)
       tags {
         "$Tags.COMPONENT" SpringWebHttpServerDecorator.DECORATE.component()
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         defaultTags()
         if (spanErrored) {
           errorTags(Exception, endpoint.body)


### PR DESCRIPTION
Only the local root span can have span.kind=server, because otherwise
it leads to undesired endpoint metrics in PG.