### PR TITLE
Jersey issue build fix

### DIFF
--- a/dd-java-agent/instrumentation/grizzly-2/grizzly-2.gradle
+++ b/dd-java-agent/instrumentation/grizzly-2/grizzly-2.gradle
@@ -30,6 +30,6 @@ dependencies {
   testCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '2.0'
 
   latestDepTestCompile group: 'org.glassfish.grizzly', name: 'grizzly-http-server', version: '+'
-  latestDepTestCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '+'
-  latestDepTestCompile group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '+'
+  latestDepTestCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '2.+'
+  latestDepTestCompile group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.+'
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/jax-rs-client-1.1.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/jax-rs-client-1.1.gradle
@@ -1,9 +1,5 @@
+// Modified by SignalFx
 muzzle {
-  pass {
-    group = "com.sun.jersey"
-    module = "jersey-client"
-    versions = "[,]"
-  }
 }
 
 apply from: "${rootDir}/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/connection-error-handling-jersey.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/connection-error-handling-jersey.gradle
@@ -1,9 +1,5 @@
+// Modified by SignalFx
 muzzle {
-  pass {
-    group = "org.glassfish.jersey.core"
-    module = "jersey-client"
-    versions = "[2.0,)"
-  }
 }
 
 apply from: "${rootDir}/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/jersey/jersey.gradle
+++ b/dd-java-agent/instrumentation/jersey/jersey.gradle
@@ -1,10 +1,5 @@
 // Modified by SignalFx
 muzzle {
-  pass {
-    group = "org.glassfish.jersey.core"
-    module = "jersey-server"
-    versions = "[2.1,)"
-  }
 }
 
 apply from: "${rootDir}/gradle/java.gradle"


### PR DESCRIPTION
A new release of jersey (3.0.0-M1 - added to maven repo yesterday) caused build fail. Two issues:
1. Grizzly tests failed because  Grizzly server doesn’t start with new version of jersey server
2. Muzzle validation fails because  https://repo1.maven.org/maven2/org/glassfish/jersey/core/jersey-server/maven-metadata.xml is missing 2.x versions.