### PR TITLE
Don't set zipkin parentId on root spans

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
@@ -183,7 +183,10 @@ public class ZipkinV2Api implements Api {
     writeIdField(jsonGenerator, "id", span.getSpanId());
     jsonGenerator.writeStringField("name", spanName);
     writeIdField(jsonGenerator, "traceId", span.getTraceId());
-    writeIdField(jsonGenerator, "parentId", span.getParentId());
+    final String parentId = span.getParentId();
+    if (!parentId.equals("0")) {
+      writeIdField(jsonGenerator, "parentId", span.getParentId());
+    }
 
     if (!Strings.isNullOrEmpty(spanKind)) {
       jsonGenerator.writeStringField("kind", spanKind);

--- a/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/ZipkinV2ApiTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/api/writer/ZipkinV2ApiTest.groovy
@@ -84,7 +84,6 @@ class ZipkinV2ApiTest extends DDSpecification {
     [[SpanFactory.newSpanOf(1L).setTag("service", "my-service").log(1000L, "some event")]]     | [new TreeMap<>([
       "traceId" : "0000000000000001",
       "id"  :     "0000000000000001",
-      "parentId": "0000000000000000",
       "duration" : 0,
       "tags"     : ["thread.name": Thread.currentThread().getName(),
                     "thread.id": "${Thread.currentThread().id}",
@@ -97,7 +96,6 @@ class ZipkinV2ApiTest extends DDSpecification {
     [[SpanFactory.newSpanOf(100L).setTag("resource.name", "my-resource")]] | [new TreeMap<>([
       "traceId" : "0000000000000001",
       "id"  :     "0000000000000001",
-      "parentId": "0000000000000000",
       "duration" : 0,
       "tags"     : ["thread.name": Thread.currentThread().getName(),
                     "thread.id": "${Thread.currentThread().id}",
@@ -110,7 +108,6 @@ class ZipkinV2ApiTest extends DDSpecification {
     [[SpanFactory.newSpanOf(100L).setTag("span.kind", "CliEnt").log(1000L, "some event").log(2000L, Collections.singletonMap("another event", 1))]] | [new TreeMap<>([
       "traceId" : "0000000000000001",
       "id"  :     "0000000000000001",
-      "parentId": "0000000000000000",
       "duration" : 0,
       "tags"     : ["thread.name": Thread.currentThread().getName(),
                     "thread.id": "${Thread.currentThread().id}",
@@ -124,7 +121,6 @@ class ZipkinV2ApiTest extends DDSpecification {
     [[SpanFactory.newSpanOf(100L).setTag("span.kind", "SerVeR")]] | [new TreeMap<>([
       "traceId" : "0000000000000001",
       "id"  :     "0000000000000001",
-      "parentId": "0000000000000000",
       "duration" : 0,
       "tags"     : ["thread.name": Thread.currentThread().getName(),
                     "thread.id": "${Thread.currentThread().id}"],


### PR DESCRIPTION
The current OTel collector will drop these root spans so it's better to avoid setting the unnecessary field.