### PR TITLE
Do not create spans/scopes for vertx timers when not in already in a trace context

### DIFF
--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxServerTest.groovy
@@ -380,4 +380,16 @@ class VertxServerTest extends AgentTestRunner {
       }
     }
   }
+
+  def "test timer does not cause traces/spans"() {
+    when:
+    Vertx vertx = Vertx.vertx()
+    long timerId = vertx.setPeriodic 50, { t -> /*nop*/ }
+    Thread.sleep(1000)
+    vertx.cancelTimer(timerId)
+    then:
+    assertTraces(0) {
+    }
+
+  }
 }


### PR DESCRIPTION
This was tested at the customer site and confirmed to fix their leak.