### PR TITLE
Version 0.36.0-sfx8

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -128,7 +128,7 @@ public class Config {
   public static final String TRACING_LIBRARY_KEY = "signalfx.tracing.library";
   public static final String TRACING_LIBRARY_VALUE = "java-tracing";
   public static final String TRACING_VERSION_KEY = "signalfx.tracing.version";
-  public static final String TRACING_VERSION_VALUE = "0.36.0-sfx7";
+  public static final String TRACING_VERSION_VALUE = "0.36.0-sfx8";
   public static final String DEFAULT_GLOBAL_TAGS =
       String.format(
           "%s:%s,%s:%s",

--- a/signalfx-java-tracing.gradle
+++ b/signalfx-java-tracing.gradle
@@ -18,7 +18,7 @@ def isCI = System.getenv("CI") != null
 allprojects {
   group = 'com.signalfx.public'
   // Don't forget to update TRACING_VERSION_VALUE in dd-trace-api/src/main/java/datadog/trace/api/Config.java
-  version = '0.36.0-sfx7'
+  version = '0.36.0-sfx8'
 
   if (isCI) {
     buildDir = "${rootDir}/workspace/${projectDir.path.replace(rootDir.path, '')}/build/"


### PR DESCRIPTION
* Do not create spans/scopes for vertx timers when not in already in a trace context.