### PR TITLE
Only set tracing library tags on local root

### DIFF
--- a/dd-java-agent/instrumentation/vertx/src/handlerTests/groovy/VertxServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/handlerTests/groovy/VertxServerTest.groovy
@@ -64,7 +64,7 @@ class VertxServerTest extends AgentTestRunner {
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" Integer
             "handler.type" "io.vertx.ext.web.impl.RoutingContextImpl"
-            defaultTags(true)
+            defaultTags()
           }
         }
         span(1) {
@@ -82,7 +82,7 @@ class VertxServerTest extends AgentTestRunner {
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            defaultTags()
+            defaultTags(true)
           }
         }
         span(2) {
@@ -312,6 +312,7 @@ class VertxServerTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
+          childOf span(1)
           traceId "123"
           serviceName "unnamed-java-app"
           operationName "VertxWebTestServer\$\$Lambda.handle"
@@ -326,7 +327,7 @@ class VertxServerTest extends AgentTestRunner {
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" Integer
             "handler.type" "io.vertx.ext.web.impl.RoutingContextImpl"
-            defaultTags(true)
+            defaultTags()
           }
         }
         span(1) {

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxServerTest.groovy
@@ -66,7 +66,7 @@ class VertxServerTest extends AgentTestRunner {
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" Integer
             "handler.type" "io.vertx.ext.web.impl.RoutingContextImpl"
-            defaultTags(true)
+            defaultTags()
           }
         }
         span(1) {
@@ -84,7 +84,7 @@ class VertxServerTest extends AgentTestRunner {
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" Integer
             "$Tags.SPAN_KIND.key" Tags.SPAN_KIND_SERVER
-            defaultTags()
+            defaultTags(true)
           }
         }
         span(2) {
@@ -328,7 +328,7 @@ class VertxServerTest extends AgentTestRunner {
             "$Tags.PEER_HOST_IPV4.key" "127.0.0.1"
             "$Tags.PEER_PORT.key" Integer
             "handler.type" "io.vertx.ext.web.impl.RoutingContextImpl"
-            defaultTags(true)
+            defaultTags()
           }
         }
         span(1) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -42,8 +42,10 @@ class TagsAssert {
 
     assert tags["thread.name"] != null
     assert tags["thread.id"] != null
-    assert tags[Config.TRACING_LIBRARY_KEY] == Config.TRACING_LIBRARY_VALUE
-    assert tags[Config.TRACING_VERSION_KEY] == Config.TRACING_VERSION_VALUE
+    if (distributedRootSpan) {
+      assert tags[Config.TRACING_LIBRARY_KEY] == Config.TRACING_LIBRARY_VALUE
+      assert tags[Config.TRACING_VERSION_KEY] == Config.TRACING_VERSION_VALUE
+    }
     assert tags[Config.RUNTIME_ID_TAG] == null
     assert tags[Config.LANGUAGE_TAG_KEY] == null
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -129,10 +129,6 @@ public class Config {
   public static final String TRACING_LIBRARY_VALUE = "java-tracing";
   public static final String TRACING_VERSION_KEY = "signalfx.tracing.version";
   public static final String TRACING_VERSION_VALUE = "0.36.0-sfx8";
-  public static final String DEFAULT_GLOBAL_TAGS =
-      String.format(
-          "%s:%s,%s:%s",
-          TRACING_LIBRARY_KEY, TRACING_LIBRARY_VALUE, TRACING_VERSION_KEY, TRACING_VERSION_VALUE);
 
   private static final boolean DEFAULT_TRACE_ENABLED = true;
   public static final boolean DEFAULT_INTEGRATIONS_ENABLED = true;
@@ -307,7 +303,7 @@ public class Config {
         getBooleanSettingFromEnvironment(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
     serviceMapping = getMapSettingFromEnvironment(SERVICE_MAPPING, null);
 
-    globalTags = getMapSettingFromEnvironment(GLOBAL_TAGS, DEFAULT_GLOBAL_TAGS);
+    globalTags = getMapSettingFromEnvironment(GLOBAL_TAGS, null);
     spanTags = getMapSettingFromEnvironment(SPAN_TAGS, null);
     jmxTags = getMapSettingFromEnvironment(JMX_TAGS, null);
 
@@ -579,6 +575,8 @@ public class Config {
   public Map<String, String> getLocalRootSpanTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final Map<String, String> result = new HashMap<>(runtimeTags);
+    result.put(TRACING_LIBRARY_KEY, TRACING_LIBRARY_VALUE);
+    result.put(TRACING_VERSION_KEY, TRACING_VERSION_VALUE);
 
     if (reportHostName) {
       final String hostName = getHostName();

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -102,9 +102,9 @@ class ConfigTest extends DDSpecification {
     config.prioritySamplingEnabled == false
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
-    config.mergedSpanTags == [(TRACING_LIBRARY_KEY):TRACING_LIBRARY_VALUE, (TRACING_VERSION_KEY):TRACING_VERSION_VALUE]
-    config.mergedJmxTags == [(SERVICE): config.serviceName, (TRACING_LIBRARY_KEY):TRACING_LIBRARY_VALUE,
-                             (TRACING_VERSION_KEY):TRACING_VERSION_VALUE]
+    config.mergedSpanTags == [:]
+    config.mergedJmxTags == [(SERVICE): config.serviceName]
+    config.getLocalRootSpanTags() == [(TRACING_LIBRARY_KEY):TRACING_LIBRARY_VALUE, (TRACING_VERSION_KEY):TRACING_VERSION_VALUE]
     config.headerTags == [:]
     config.httpServerErrorStatuses == (500..599).toSet()
     config.httpClientErrorStatuses == (500..599).toSet()
@@ -427,7 +427,7 @@ class ConfigTest extends DDSpecification {
     config.prioritySamplingEnabled == false
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
-    config.mergedSpanTags == [(TRACING_LIBRARY_KEY):TRACING_LIBRARY_VALUE, (TRACING_VERSION_KEY):TRACING_VERSION_VALUE]
+    config.mergedSpanTags == [:]
     config.headerTags == [:]
     config.httpServerErrorStatuses == (500..599).toSet()
     config.httpClientErrorStatuses == (500..599).toSet()


### PR DESCRIPTION
These changes move the version information from default global tags to those of the local root.