### PR TITLE
Don't derive Zipkin server kind from span type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,16 +113,6 @@ jobs:
     environment:
     - TEST_TASK: testJavaZULU8
 
-  test_9:
-    <<: *default_test_job
-    environment:
-    - TEST_TASK: testJava9
-
-  test_10:
-    <<: *default_test_job
-    environment:
-    - TEST_TASK: testJava10
-
   test_11:
     <<: *default_test_job
     environment:
@@ -257,18 +247,6 @@ workflows:
           tags:
             only: /.*/
     - test_zulu8:
-        requires:
-        - build
-        filters:
-          tags:
-            only: /.*/
-    - test_9:
-        requires:
-        - build
-        filters:
-          tags:
-            only: /.*/
-    - test_10:
         requires:
         - build
         filters:

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ZipkinV2Api.java
@@ -260,8 +260,6 @@ public class ZipkinV2Api implements Api {
       switch (span.getSpanType()) {
         case DDSpanTypes.HTTP_CLIENT:
           return DDTags.SPAN_KIND_CLIENT;
-        case DDSpanTypes.HTTP_SERVER:
-          return DDTags.SPAN_KIND_SERVER;
       }
     }
     return null;
@@ -278,8 +276,9 @@ public class ZipkinV2Api implements Api {
     String resourceName = span.getResourceName();
 
     if (!Strings.isNullOrEmpty(resourceName)
-        && !Strings.isNullOrEmpty(spanKind)
-        && spanKind.equalsIgnoreCase(DDTags.SPAN_KIND_SERVER)) {
+        && ((!Strings.isNullOrEmpty(spanKind) && spanKind.equalsIgnoreCase(DDTags.SPAN_KIND_SERVER))
+            || (!Strings.isNullOrEmpty(span.getSpanType())
+                && span.getSpanType().equalsIgnoreCase(DDSpanTypes.HTTP_SERVER)))) {
       return resourceName;
     }
 


### PR DESCRIPTION
Ensures the intended behavior of https://github.com/signalfx/signalfx-java-tracing/commit/ecbe03ade3a2dc2de2da144d335868d838123b63 functionality persists through span encoding.

Also removes java 9 and 10 CI test runs since the test image no longer sets their respective `JAVA_x_HOME`.