### PR TITLE
Normalize away path segments that contain "@"

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java
@@ -11,7 +11,7 @@ public class URLAsResourceName extends AbstractDecorator {
 
   // Matches any path segments with numbers in them. (exception for versioning: "/v1/")
   public static final Pattern PATH_MIXED_ALPHANUMERICS =
-      Pattern.compile("(?<=/)(?![vV]\\d{1,2}/)(?:[^\\/\\d\\?]*[\\d]+[^\\/\\?]*)");
+      Pattern.compile("(?<=/)(?![vV]\\d{1,2}/)(?:[^\\/\\d\\?]*[\\d@]+[^\\/\\?]*)");
 
   public URLAsResourceName() {
     super();

--- a/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 public class URLAsResourceName extends AbstractDecorator {
 
   // Matches any path segments with numbers in them. (exception for versioning: "/v1/")
-  public static final Pattern PATH_MIXED_ALPHANUMERICS =
+  public static final Pattern PATH_MIXED_ALPHANUMERICS_AND_EMAILS =
       Pattern.compile("(?<=/)(?![vV]\\d{1,2}/)(?:[^\\/\\d\\?]*[\\d@]+[^\\/\\?]*)");
 
   public URLAsResourceName() {
@@ -91,7 +91,7 @@ public class URLAsResourceName extends AbstractDecorator {
       return "/";
     }
 
-    return PATH_MIXED_ALPHANUMERICS.matcher(path).replaceAll("?");
+    return PATH_MIXED_ALPHANUMERICS_AND_EMAILS.matcher(path).replaceAll("?");
   }
 
   private String addMethodIfAvailable(final DDSpanContext context, String path) {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
@@ -83,6 +83,11 @@ class URLAsResourceNameTest extends DDSpecification {
     "/ABC/av-1/b_2/c.3/d4d/v5f/v699/7"                 | "/ABC/?/?/?/?/?/?/?"
     "/user/asdf123/repository/01234567-9ABC-DEF0-1234" | "/user/?/repository/?"
     "/user/1/repo/test@example.com/"                   | "/user/?/repo/?/"
+    "/user123@host-456.biz"                            | "/?"
+    "/a@b@c"                                           | "/?"
+    "/@nothing-before-at.com"                          | "/?"
+    "/endsinat@/includedsegment"                       | "/?/includedsegment"
+    "/@"                                               | "/?"
   }
 
   def "should leave other segments alone"() {

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
@@ -82,6 +82,7 @@ class URLAsResourceNameTest extends DDSpecification {
     "/V01/v9/abc/-1"                                   | "/V01/v9/abc/?"
     "/ABC/av-1/b_2/c.3/d4d/v5f/v699/7"                 | "/ABC/?/?/?/?/?/?/?"
     "/user/asdf123/repository/01234567-9ABC-DEF0-1234" | "/user/?/repository/?"
+    "/user/1/repo/test@example.com/"                   | "/user/?/repo/?/"
   }
 
   def "should leave other segments alone"() {
@@ -127,13 +128,13 @@ class URLAsResourceNameTest extends DDSpecification {
     context.resourceName == resourceName
 
     where:
-    value                       | resourceName        | tags
-    null                        | "fakeResource"      | [:]
-    " "                         | "/"                 | [:]
-    "\t"                        | "/"                 | [:]
-    "/path"                     | "/path"             | [:]
-    "/ABC/a-1/b_2/c.3/d4d/5f/6" | "/ABC/?/?/?/?/?/?"  | [:]
-    "/not-found"                | "fakeResource"      | [(Tags.HTTP_STATUS.key): 404]
-    "/with-method"              | "/with-method"      | [(Tags.HTTP_METHOD.key): "Post"]
+    value                       | resourceName       | tags
+    null                        | "fakeResource"     | [:]
+    " "                         | "/"                | [:]
+    "\t"                        | "/"                | [:]
+    "/path"                     | "/path"            | [:]
+    "/ABC/a-1/b_2/c.3/d4d/5f/6" | "/ABC/?/?/?/?/?/?" | [:]
+    "/not-found"                | "fakeResource"     | [(Tags.HTTP_STATUS.key): 404]
+    "/with-method"              | "/with-method"     | [(Tags.HTTP_METHOD.key): "Post"]
   }
 }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/decorators/URLAsResourceNameTest.groovy
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 package datadog.opentracing.decorators
 
 import datadog.opentracing.DDSpanContext


### PR DESCRIPTION
Potential fix for SWAT-1618: too high cardinality operation names when they contain email addresses.