### PR TITLE
Optionally pass trace context in http response via Server-Timing.

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
@@ -3,10 +3,21 @@ package datadog.trace.bootstrap.instrumentation;
 import datadog.trace.api.Ids;
 import io.opentracing.SpanContext;
 import java.math.BigInteger;
+import java.util.Arrays;
 
 public class TraceParentHeaderFormatter {
 
-  public static String format(SpanContext context) {
+  public static char[] padTo128(final char[] id) {
+    if (id.length == 32) {
+      return id;
+    }
+    char[] answer = new char[32];
+    Arrays.fill(answer, '0');
+    System.arraycopy(id, 0, answer, 32 - id.length, id.length);
+    return answer;
+  }
+
+  public static String format(final SpanContext context) {
     // https://www.w3.org/TR/server-timing/
     // https://www.w3.org/TR/trace-context/#traceparent-header
     StringBuffer traceParent = new StringBuffer();
@@ -15,7 +26,7 @@ public class TraceParentHeaderFormatter {
     String spanIdDec = context.toSpanId();
 
     traceParent.append("traceparent;desc=\"00-");
-    traceParent.append(Ids.idToHexChars(new BigInteger(traceIdDec)));
+    traceParent.append(padTo128(Ids.idToHexChars(new BigInteger(traceIdDec))));
     traceParent.append("-");
     traceParent.append(Ids.idToHexChars(new BigInteger(spanIdDec)));
     traceParent.append("-01\"");

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
@@ -7,6 +7,8 @@ import java.math.BigInteger;
 public class TraceParentHeaderFormatter {
 
   public static String format(SpanContext context) {
+    // https://www.w3.org/TR/server-timing/
+    // https://www.w3.org/TR/trace-context/#traceparent-header
     StringBuffer traceParent = new StringBuffer();
     // FIXME Allocations/transformations here are unnecessary given better internal interfaces
     String traceIdDec = context.toTraceId();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
@@ -1,0 +1,22 @@
+package datadog.trace.bootstrap.instrumentation;
+
+import datadog.trace.api.Ids;
+import io.opentracing.SpanContext;
+import java.math.BigInteger;
+
+public class TraceParentHeaderFormatter {
+
+  public static String format(SpanContext context) {
+    StringBuffer traceParent = new StringBuffer();
+    // FIXME Allocations/transformations here are unnecessary given better internal interfaces
+    String traceIdDec = context.toTraceId();
+    String spanIdDec = context.toSpanId();
+
+    traceParent.append("traceparent;desc=\"00-");
+    traceParent.append(Ids.idToHexChars(new BigInteger(traceIdDec)));
+    traceParent.append("-");
+    traceParent.append(Ids.idToHexChars(new BigInteger(spanIdDec)));
+    traceParent.append("-01\"");
+    return traceParent.toString();
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
@@ -6,10 +6,9 @@ import java.math.BigInteger;
 import java.util.Arrays;
 
 /**
- * Formats a <a href="https://www.w3.org/TR/server-timing/">Server-Timing</a> header
- * value carrying a trace context in the
- * <a href="https://www.w3.org/TR/trace-context/#traceparent-header">traceparent</a>
- * format.
+ * Formats a <a href="https://www.w3.org/TR/server-timing/">Server-Timing</a> header value carrying
+ * a trace context in the <a
+ * href="https://www.w3.org/TR/trace-context/#traceparent-header">traceparent</a> format.
  */
 public class TraceParentHeaderFormatter {
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
@@ -5,6 +5,12 @@ import io.opentracing.SpanContext;
 import java.math.BigInteger;
 import java.util.Arrays;
 
+/**
+ * Formats a <a href="https://www.w3.org/TR/server-timing/">Server-Timing</a> header
+ * value carrying a trace context in the
+ * <a href="https://www.w3.org/TR/trace-context/#traceparent-header">traceparent</a>
+ * format.
+ */
 public class TraceParentHeaderFormatter {
 
   public static char[] padTo128(final char[] id) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/TraceParentHeaderFormatter.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
  */
 public class TraceParentHeaderFormatter {
 
-  public static char[] padTo128(final char[] id) {
+  private static char[] padTo128(final char[] id) {
     if (id.length == 32) {
       return id;
     }

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -87,6 +87,7 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Default {
       if (Config.get().isEmitServerTimingContext() && response != null) {
         response.addHeader(
             "Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
+        response.addHeader("Access-Control-Expose-Headers", "Server-Timing");
       }
 
       request.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -69,7 +69,8 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Default {
   public static class HandleAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static AgentScope methodEnter(@Advice.Argument(0) final Request request, @Advice.Argument(1) final Response response) {
+    public static AgentScope methodEnter(
+        @Advice.Argument(0) final Request request, @Advice.Argument(1) final Response response) {
       if (request.getAttribute(DD_SPAN_ATTRIBUTE) != null) {
         return null;
       }
@@ -84,7 +85,8 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Default {
       scope.setAsyncPropagation(true);
 
       if (Config.get().isEmitServerTimingContext() && response != null) {
-        response.addHeader("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+        response.addHeader(
+            "Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
       }
 
       request.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
@@ -115,6 +115,7 @@ class GrizzlyTest extends HttpServerTest<HttpServer> {
 
     expect:
     response.headers().toMultimap().get("Server-Timing").join(',').contains("traceparent")
+    response.headers().toMultimap().get("Access-Control-Expose-Headers").join(',').contains("Server-Timing")
   }
 
 }

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
@@ -110,7 +110,7 @@ class GrizzlyTest extends HttpServerTest<HttpServer> {
     def response = null
     withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
       def request = request(HttpServerTest.ServerEndpoint.SUCCESS, "GET", null).build()
-      response = client.newCall(request).execute();
+      response = client.newCall(request).execute()
     }
 
     expect:

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
@@ -1,4 +1,7 @@
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
+
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.Config
 import datadog.trace.instrumentation.grizzly.GrizzlyDecorator
 import org.glassfish.grizzly.http.server.HttpServer
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
@@ -101,4 +104,17 @@ class GrizzlyTest extends HttpServerTest<HttpServer> {
       return null
     }
   }
+
+  def "server-timing traceparent is emitted when configured"() {
+    setup:
+    def response = null
+    withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
+      def request = request(HttpServerTest.ServerEndpoint.SUCCESS, "GET", null).build()
+      response = client.newCall(request).execute();
+    }
+
+    expect:
+    response.headers().toMultimap().get("Server-Timing").join(',').contains("traceparent")
+  }
+
 }

--- a/dd-java-agent/instrumentation/jetty-6/src/main/java/datadog/trace/instrumentation/jetty6/JettyHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-6/src/main/java/datadog/trace/instrumentation/jetty6/JettyHandlerAdvice.java
@@ -22,7 +22,9 @@ public class JettyHandlerAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(
-      @Advice.This final Object source, @Advice.Argument(1) final HttpServletRequest req, @Advice.Argument(2) final HttpServletResponse res) {
+      @Advice.This final Object source,
+      @Advice.Argument(1) final HttpServletRequest req,
+      @Advice.Argument(2) final HttpServletResponse res) {
 
     if (req.getAttribute(DD_SPAN_ATTRIBUTE) != null) {
       // Request already being traced elsewhere.
@@ -47,7 +49,8 @@ public class JettyHandlerAdvice {
     scope.setAsyncPropagation(true);
 
     if (Config.get().isEmitServerTimingContext() && res != null) {
-      res.addHeader("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+      res.addHeader(
+          "Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
     }
 
     req.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/jetty-6/src/main/java/datadog/trace/instrumentation/jetty6/JettyHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-6/src/main/java/datadog/trace/instrumentation/jetty6/JettyHandlerAdvice.java
@@ -51,6 +51,7 @@ public class JettyHandlerAdvice {
     if (Config.get().isEmitServerTimingContext() && res != null) {
       res.addHeader(
           "Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
+      res.addHeader("Access-Control-Expose-Headers", "Server-Timing");
     }
 
     req.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/jetty-6/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-6/src/test/groovy/JettyHandlerTest.groovy
@@ -1,7 +1,11 @@
 //Modified by SignalFx
+
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
+
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import okhttp3.OkHttpClient
 import org.mortbay.jetty.Handler
@@ -120,5 +124,35 @@ class JettyHandlerTest extends AgentTestRunner {
         }
       }
     }
+  }
+
+  def "server-timing traceparent is emitted when configured"() {
+    setup:
+    def response = null
+    withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
+      Handler handler = new AbstractHandler() {
+        @Override
+        void handle(String target, HttpServletRequest request, HttpServletResponse response2, int dispatch) throws IOException, ServletException {
+          response2.setContentType("text/plain;charset=utf-8")
+          response2.setStatus(HttpServletResponse.SC_OK)
+
+          Request baseRequest = (request instanceof Request) ? (Request) request : HttpConnection.getCurrentConnection().getRequest()
+          baseRequest.setHandled(true)
+          response2.getWriter().println("Hello World")
+        }
+      }
+      server.setHandler(handler)
+      server.start()
+      def request = new okhttp3.Request.Builder()
+        .url("http://localhost:$port/")
+        .get()
+        .build()
+      response = client.newCall(request).execute()
+    }
+
+    expect:
+    response.headers().toMultimap().get("Server-Timing").join(',').contains("traceparent")
+    response.body().string().trim() == "Hello World"
+
   }
 }

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
@@ -55,6 +55,7 @@ public class JettyHandlerAdvice {
     if (Config.get().isEmitServerTimingContext() && res != null) {
       res.addHeader(
           "Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
+      res.addHeader("Access-Control-Expose-Headers", "Server-Timing");
     }
 
     req.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
@@ -26,7 +26,9 @@ public class JettyHandlerAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(
-      @Advice.This final Object source, @Advice.Argument(2) final HttpServletRequest req, @Advice.Argument(3) final HttpServletResponse res) {
+      @Advice.This final Object source,
+      @Advice.Argument(2) final HttpServletRequest req,
+      @Advice.Argument(3) final HttpServletResponse res) {
 
     if (req.getAttribute(DD_SPAN_ATTRIBUTE) != null) {
       // Request already being traced elsewhere.
@@ -51,7 +53,8 @@ public class JettyHandlerAdvice {
     scope.setAsyncPropagation(true);
 
     if (Config.get().isEmitServerTimingContext() && res != null) {
-      res.addHeader("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+      res.addHeader(
+          "Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
     }
 
     req.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerAdvice.java
@@ -8,12 +8,15 @@ import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecora
 import static datadog.trace.instrumentation.jetty8.HttpServletRequestExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.jetty8.JettyDecorator.DECORATE;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.GlobalTracer;
+import datadog.trace.bootstrap.instrumentation.TraceParentHeaderFormatter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import io.opentracing.SpanContext;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -23,7 +26,7 @@ public class JettyHandlerAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(
-      @Advice.This final Object source, @Advice.Argument(2) final HttpServletRequest req) {
+      @Advice.This final Object source, @Advice.Argument(2) final HttpServletRequest req, @Advice.Argument(3) final HttpServletResponse res) {
 
     if (req.getAttribute(DD_SPAN_ATTRIBUTE) != null) {
       // Request already being traced elsewhere.
@@ -46,6 +49,11 @@ public class JettyHandlerAdvice {
 
     final AgentScope scope = activateSpan(span, false);
     scope.setAsyncPropagation(true);
+
+    if (Config.get().isEmitServerTimingContext() && res != null) {
+      res.addHeader("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+    }
+
     req.setAttribute(DD_SPAN_ATTRIBUTE, span);
     req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());
     req.setAttribute(CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -1,10 +1,15 @@
 // Modified by SignalFx
+
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
+
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.jetty8.JettyDecorator
+import okhttp3.Response
 import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
@@ -152,5 +157,17 @@ class JettyHandlerTest extends HttpServerTest<Server> {
         defaultTags(true)
       }
     }
+  }
+
+  def "server-timing traceparent is emitted when configured"() {
+    setup:
+    def response = null
+    withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
+      def request = request(HttpServerTest.ServerEndpoint.SUCCESS, "GET", null).build()
+      response = client.newCall(request).execute();
+    }
+
+    expect:
+    response.headers().toMultimap().get("Server-Timing").join(',').contains("traceparent")
   }
 }

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -168,5 +168,6 @@ class JettyHandlerTest extends HttpServerTest<Server> {
 
     expect:
     response.headers().toMultimap().get("Server-Timing").join(',').contains("traceparent")
+    response.headers().toMultimap().get("Access-Control-Expose-Headers").join(',').contains("Server-Timing")
   }
 }

--- a/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -9,7 +9,6 @@ import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.jetty8.JettyDecorator
-import okhttp3.Response
 import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
@@ -164,7 +163,7 @@ class JettyHandlerTest extends HttpServerTest<Server> {
     def response = null
     withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
       def request = request(HttpServerTest.ServerEndpoint.SUCCESS, "GET", null).build()
-      response = client.newCall(request).execute();
+      response = client.newCall(request).execute()
     }
 
     expect:

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
@@ -41,6 +41,7 @@ public class HttpServerResponseTracingHandler extends SimpleChannelDownstreamHan
       response
           .headers()
           .add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
+      response.headers().add("Access-Control-Expose-Headers", "Server-Timing");
     }
 
     try {

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
@@ -38,7 +38,9 @@ public class HttpServerResponseTracingHandler extends SimpleChannelDownstreamHan
 
     final HttpResponse response = (HttpResponse) msg.getMessage();
     if (Config.get().isEmitServerTimingContext() && response != null) {
-      response.headers().add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+      response
+          .headers()
+          .add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
     }
 
     try {

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
@@ -2,10 +2,13 @@ package datadog.trace.instrumentation.netty38.server;
 
 import static datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator.DECORATE;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.instrumentation.TraceParentHeaderFormatter;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.instrumentation.netty38.ChannelTraceContext;
+import io.opentracing.SpanContext;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
@@ -34,6 +37,9 @@ public class HttpServerResponseTracingHandler extends SimpleChannelDownstreamHan
     }
 
     final HttpResponse response = (HttpResponse) msg.getMessage();
+    if (Config.get().isEmitServerTimingContext() && response != null) {
+      response.headers().add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+    }
 
     try {
       ctx.sendDownstream(msg);

--- a/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/Netty38ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/Netty38ServerTest.groovy
@@ -154,7 +154,7 @@ class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
     def response = null
     withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
       def request = request(HttpServerTest.ServerEndpoint.SUCCESS, "GET", null).build()
-      response = client.newCall(request).execute();
+      response = client.newCall(request).execute()
     }
 
     expect:

--- a/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/Netty38ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/Netty38ServerTest.groovy
@@ -159,6 +159,7 @@ class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
 
     expect:
     response.headers().toMultimap().get("Server-Timing").join(',').contains("traceparent")
+    response.headers().toMultimap().get("Access-Control-Expose-Headers").join(',').contains("Server-Timing")
   }
 
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
@@ -3,6 +3,8 @@ package datadog.trace.instrumentation.netty40.server;
 
 import static datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator.DECORATE;
 
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.TraceParentHeaderFormatter;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.netty40.AttributeKeys;
 import datadog.trace.instrumentation.netty40.NettyUtils;
@@ -10,6 +12,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpResponse;
+import io.opentracing.SpanContext;
 
 public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdapter {
 
@@ -22,6 +25,9 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
     }
 
     final HttpResponse response = (HttpResponse) msg;
+    if (Config.get().isEmitServerTimingContext() && response != null) {
+      response.headers().add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+    }
 
     try {
       ctx.write(msg, prm);

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
@@ -26,7 +26,9 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
 
     final HttpResponse response = (HttpResponse) msg;
     if (Config.get().isEmitServerTimingContext() && response != null) {
-      response.headers().add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+      response
+          .headers()
+          .add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
     }
 
     try {

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
@@ -29,6 +29,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       response
           .headers()
           .add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
+      response.headers().add("Access-Control-Expose-Headers", "Server-Timing");
     }
 
     try {

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -190,6 +190,7 @@ class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
 
     expect:
     response.headers().toMultimap().get("Server-Timing").join(',').contains("traceparent")
+    response.headers().toMultimap().get("Access-Control-Expose-Headers").join(',').contains("Server-Timing")
   }
 
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -1,5 +1,9 @@
 // Modified by SignalFx
+
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
+
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty40.NettyUtils
@@ -175,4 +179,17 @@ class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
     UNAVAILABLE | true  | false
     UNAVAILABLE | false | true
   }
+
+  def "server-timing traceparent is emitted when configured"() {
+    setup:
+    def response = null
+    withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
+      def request = request(HttpServerTest.ServerEndpoint.SUCCESS, "GET", null).build()
+      response = client.newCall(request).execute();
+    }
+
+    expect:
+    response.headers().toMultimap().get("Server-Timing").join(',').contains("traceparent")
+  }
+
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -185,7 +185,7 @@ class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
     def response = null
     withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
       def request = request(HttpServerTest.ServerEndpoint.SUCCESS, "GET", null).build()
-      response = client.newCall(request).execute();
+      response = client.newCall(request).execute()
     }
 
     expect:

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
@@ -3,6 +3,8 @@ package datadog.trace.instrumentation.netty41.server;
 
 import static datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator.DECORATE;
 
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.TraceParentHeaderFormatter;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.netty41.AttributeKeys;
 import datadog.trace.instrumentation.netty41.NettyUtils;
@@ -10,6 +12,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpResponse;
+import io.opentracing.SpanContext;
 
 public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdapter {
 
@@ -22,6 +25,9 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
     }
 
     final HttpResponse response = (HttpResponse) msg;
+    if (Config.get().isEmitServerTimingContext() && response != null) {
+      response.headers().add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+    }
 
     try {
       ctx.write(msg, prm);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
@@ -26,7 +26,9 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
 
     final HttpResponse response = (HttpResponse) msg;
     if (Config.get().isEmitServerTimingContext() && response != null) {
-      response.headers().add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+      response
+          .headers()
+          .add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
     }
 
     try {

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
@@ -29,6 +29,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       response
           .headers()
           .add("Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
+      response.headers().add("Access-Control-Expose-Headers", "Server-Timing");
     }
 
     try {

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
@@ -1,6 +1,18 @@
 // Modified by SignalFx
 
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNAVAILABLE
 import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
 
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.Config
@@ -27,18 +39,6 @@ import io.netty.handler.codec.http.HttpServerCodec
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.util.CharsetUtil
-
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNAVAILABLE
-import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH
-import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
-import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
 
 class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
 
@@ -189,6 +189,7 @@ class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
 
     expect:
     response.headers().toMultimap().get("Server-Timing").join(',').contains("traceparent")
+    response.headers().toMultimap().get("Access-Control-Expose-Headers").join(',').contains("Server-Timing")
   }
 
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
@@ -1,5 +1,9 @@
 // Modified by SignalFx
+
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
+
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty41.NettyUtils
@@ -174,4 +178,17 @@ class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
     UNAVAILABLE | true  | false
     UNAVAILABLE | false | true
   }
+
+  def "server-timing traceparent is emitted when configured"() {
+    setup:
+    def response = null
+    withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
+      def request = request(HttpServerTest.ServerEndpoint.SUCCESS, "GET", null).build()
+      response = client.newCall(request).execute();
+    }
+
+    expect:
+    response.headers().toMultimap().get("Server-Timing").join(',').contains("traceparent")
+  }
+
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
@@ -184,7 +184,7 @@ class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
     def response = null
     withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
       def request = request(HttpServerTest.ServerEndpoint.SUCCESS, "GET", null).build()
-      response = client.newCall(request).execute();
+      response = client.newCall(request).execute()
     }
 
     expect:

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -68,6 +68,7 @@ public class Servlet2Advice {
       HttpServletResponse hsr = (HttpServletResponse) response;
       hsr.addHeader(
           "Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
+      hsr.addHeader("Access-Control-Expose-Headers", "Server-Timing");
     }
 
     httpServletRequest.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -66,7 +66,8 @@ public class Servlet2Advice {
 
     if (Config.get().isEmitServerTimingContext() && response instanceof HttpServletResponse) {
       HttpServletResponse hsr = (HttpServletResponse) response;
-      hsr.addHeader("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+      hsr.addHeader(
+          "Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
     }
 
     httpServletRequest.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -1,6 +1,10 @@
 // Modified by SignalFx
+
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
+
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -120,6 +124,18 @@ class JettyServlet2Test extends HttpServerTest<Server> {
         defaultTags(true)
       }
     }
+  }
+
+  def "server-timing traceparent is emitted when configured"() {
+    setup:
+    def response = null
+    withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
+      def request = request(SUCCESS, "GET", null).build()
+      response = client.newCall(request).execute()
+    }
+    expect:
+    response.code() == SUCCESS.status
+    response.headers("Server-Timing").join(',').contains('traceparent')
   }
 
   /**

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -136,6 +136,7 @@ class JettyServlet2Test extends HttpServerTest<Server> {
     expect:
     response.code() == SUCCESS.status
     response.headers("Server-Timing").join(',').contains('traceparent')
+    response.headers("Access-Control-Expose-Headers").join(',').contains('Server-Timing')
   }
 
   /**

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -7,13 +7,16 @@ import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecora
 import static datadog.trace.instrumentation.servlet3.HttpServletRequestExtractAdapter.GETTER;
 import static datadog.trace.instrumentation.servlet3.Servlet3Decorator.DECORATE;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.TraceParentHeaderFormatter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import io.opentracing.SpanContext;
 import java.security.Principal;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.ServletRequest;
@@ -55,6 +58,11 @@ public class Servlet3Advice {
 
     final AgentScope scope = activateSpan(span, false);
     scope.setAsyncPropagation(true);
+
+    if (Config.get().isEmitServerTimingContext() && response instanceof HttpServletResponse) {
+      HttpServletResponse hsr = (HttpServletResponse) response;
+      hsr.addHeader("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+    }
 
     httpServletRequest.setAttribute(DD_SPAN_ATTRIBUTE, span);
     httpServletRequest.setAttribute(

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -63,6 +63,7 @@ public class Servlet3Advice {
       HttpServletResponse hsr = (HttpServletResponse) response;
       hsr.addHeader(
           "Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
+      hsr.addHeader("Access-Control-Expose-Headers", "Server-Timing");
     }
 
     httpServletRequest.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -61,7 +61,8 @@ public class Servlet3Advice {
 
     if (Config.get().isEmitServerTimingContext() && response instanceof HttpServletResponse) {
       HttpServletResponse hsr = (HttpServletResponse) response;
-      hsr.addHeader("Server-Timing", TraceParentHeaderFormatter.format((SpanContext)span.context()));
+      hsr.addHeader(
+          "Server-Timing", TraceParentHeaderFormatter.format((SpanContext) span.context()));
     }
 
     httpServletRequest.setAttribute(DD_SPAN_ATTRIBUTE, span);

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -126,6 +126,7 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
     response.code() == SUCCESS.status
     response.headers("Server-Timing").join(',').contains('traceparent')
     response.headers("Server-Timing").join(',').matches(".*traceparent;desc=\"00-[0-9a-f]{32}-[0-9a-f]{16}-01\".*")
+    response.headers("Access-Control-Expose-Headers").join(',').contains("Server-Timing")
   }
 
 }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -1,6 +1,10 @@
 // Modified by SignalFx
+
+import static datadog.trace.agent.test.utils.ConfigUtils.withConfigOverride
+
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -110,4 +114,17 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
       }
     }
   }
+
+  def "server-timing traceparent is emitted when configured"() {
+    setup:
+    def response = null
+    withConfigOverride(Config.SERVER_TIMING_CONTEXT, "true") {
+      def request = request(SUCCESS, "GET", null).build()
+      response = client.newCall(request).execute()
+    }
+    expect:
+    response.code() == SUCCESS.status
+    response.headers("Server-Timing").join(',').contains('traceparent')
+  }
+
 }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -125,6 +125,7 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
     expect:
     response.code() == SUCCESS.status
     response.headers("Server-Timing").join(',').contains('traceparent')
+    response.headers("Server-Timing").join(',').matches(".*traceparent;desc=\"00-[0-9a-f]{32}-[0-9a-f]{16}-01\".*")
   }
 
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -175,6 +175,9 @@ public class Config {
   public static final String MAX_CONTINUATION_DEPTH = "max.continuation.depth";
   public static final Integer DEFAULT_MAX_CONTINUATION_DEPTH = 100;
 
+  public static final String SERVER_TIMING_CONTEXT = "server.timing.context";
+  public static final boolean DEFAULT_SERVER_TIMING_CONTEXT = false;
+
   public static final String DEFAULT_SITE = "datadoghq.com";
   public static final String DEFAULT_SERVICE_NAME = "unnamed-java-service";
 
@@ -360,6 +363,7 @@ public class Config {
 
   @Getter private final Integer maxSpansPerTrace;
   @Getter private final Integer maxContinuationDepth;
+  @Getter private final boolean emitServerTimingContext;
   @Getter private final Map<String, String> traceSamplingServiceRules;
   @Getter private final Map<String, String> traceSamplingOperationRules;
   @Getter private final Double traceSampleRate;
@@ -545,6 +549,9 @@ public class Config {
         getIntegerSettingFromEnvironment(MAX_SPANS_PER_TRACE, DEFAULT_MAX_SPANS_PER_TRACE);
     maxContinuationDepth =
         getIntegerSettingFromEnvironment(MAX_CONTINUATION_DEPTH, DEFAULT_MAX_CONTINUATION_DEPTH);
+    emitServerTimingContext =
+        getBooleanSettingFromEnvironment(SERVER_TIMING_CONTEXT, DEFAULT_SERVER_TIMING_CONTEXT);
+
     traceSamplingServiceRules = getMapSettingFromEnvironment(TRACE_SAMPLING_SERVICE_RULES, null);
     traceSamplingOperationRules =
         getMapSettingFromEnvironment(TRACE_SAMPLING_OPERATION_RULES, null);
@@ -772,6 +779,8 @@ public class Config {
         getPropertyIntegerValue(properties, MAX_SPANS_PER_TRACE, DEFAULT_MAX_SPANS_PER_TRACE);
     maxContinuationDepth =
         getPropertyIntegerValue(properties, MAX_CONTINUATION_DEPTH, DEFAULT_MAX_CONTINUATION_DEPTH);
+    emitServerTimingContext =
+        getPropertyBooleanValue(properties, SERVER_TIMING_CONTEXT, DEFAULT_SERVER_TIMING_CONTEXT);
     traceSamplingServiceRules =
         getPropertyMapValue(
             properties, TRACE_SAMPLING_SERVICE_RULES, parent.traceSamplingServiceRules);

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -363,6 +363,10 @@ public class Config {
 
   @Getter private final Integer maxSpansPerTrace;
   @Getter private final Integer maxContinuationDepth;
+
+  // Feature for RUM that emits the trace context to the browser in a Server-Timing header
+  // on the *response* (most other propagation relies on the client to propagate on
+  // the *request*).
   @Getter private final boolean emitServerTimingContext;
   @Getter private final Map<String, String> traceSamplingServiceRules;
   @Getter private final Map<String, String> traceSamplingOperationRules;


### PR DESCRIPTION
Optionally pass trace context in http response via Server-Timing.

If SIGNALFX_SERVER_TIMING_CONTEXT is turned on, pass trace context
in traceparent form over a Server-Timing header.
    
https://www.w3.org/TR/server-timing/
https://www.w3.org/TR/trace-context/#traceparent-header