### PR TITLE
Add a separate HandlerMappingInstrumentation to update server span name when the corresponding handler got selected

### DIFF
--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -5,7 +5,6 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.im
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DECORATE;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -68,14 +67,9 @@ public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
   public static class ControllerAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static AgentScope nameResourceAndStartSpan(
+    public static AgentScope onEnter(
         @Advice.Argument(0) final HttpServletRequest request,
         @Advice.Argument(2) final Object handler) {
-      // Name the parent span based on the matching pattern
-      final Object parentSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);
-      if (parentSpan instanceof AgentSpan) {
-        DECORATE.onRequest((AgentSpan) parentSpan, request);
-      }
 
       if (activeSpan() == null) {
         return null;

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 /**
  * Instruments {@link org.springframework.web.servlet.HandlerMapping} to update SERVER span name
- * based on the mapping string of the Spring controller the was chosen to handle given request.
+ * based on the mapping string of the Spring controller that was chosen to handle given request.
  */
 @AutoService(Instrumenter.class)
 public final class HandlerMappingInstrumentation extends Instrumenter.Default {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingInstrumentation.java
@@ -1,0 +1,80 @@
+package datadog.trace.instrumentation.springweb;
+
+import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DECORATE;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Instruments {@link org.springframework.web.servlet.HandlerMapping} to update SERVER span name
+ * based on the mapping string of the Spring controller the was chosen to handle given request.
+ */
+@AutoService(Instrumenter.class)
+public final class HandlerMappingInstrumentation extends Instrumenter.Default {
+
+  public HandlerMappingInstrumentation() {
+    super("spring-web");
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // Optimization for expensive typeMatcher.
+    return hasClassesNamed("org.springframework.web.servlet.HandlerMapping");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return implementsInterface(named("org.springframework.web.servlet.HandlerMapping"));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".SpringWebHttpServerDecorator",
+      packageName + ".SpringWebHttpServerDecorator$1",
+    };
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    return singletonMap(
+        isMethod()
+            .and(named("getHandler"))
+            .and(takesArgument(0, named("javax.servlet.http.HttpServletRequest")))
+            .and(takesArguments(1)),
+        HandlerMappingInstrumentation.class.getName() + "$HandlerMappingAdvice");
+  }
+
+  public static class HandlerMappingAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void renameParentSpan(
+        @Advice.Argument(0) final HttpServletRequest request,
+        @Advice.Return final Object handlerChain) {
+      if (handlerChain != null) {
+        // Most probably instrumented HandlerMapping has set matched pattern to the request.
+        // Set that pattern as name of the parent span.
+        // We assume that paren span == SERVER span.
+        final Object parentSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);
+        if (parentSpan instanceof AgentSpan) {
+          DECORATE.onRequest((AgentSpan) parentSpan, request);
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/AppConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/AppConfig.groovy
@@ -56,13 +56,13 @@ class AppConfig extends WebMvcConfigurerAdapter {
     registry.addInterceptor(new BrokenInterceptor())
   }
 
-  public static class BrokenInterceptor extends HandlerInterceptorAdapter {
+  static class BrokenInterceptor extends HandlerInterceptorAdapter {
     @Override
     boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
       if ((handler as HandlerMethod).method.name == 'broken') {
         throw new IllegalArgumentException("Broken interceptor")
       }
-      return true;
+      return true
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/AppConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/AppConfig.groovy
@@ -1,5 +1,8 @@
 package test
 
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
 import org.apache.catalina.connector.Connector
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory
@@ -10,8 +13,11 @@ import org.springframework.http.MediaType
 import org.springframework.web.HttpMediaTypeNotAcceptableException
 import org.springframework.web.accept.ContentNegotiationStrategy
 import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.HandlerMethod
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter
 
 @SpringBootApplication
 class AppConfig extends WebMvcConfigurerAdapter {
@@ -43,5 +49,20 @@ class AppConfig extends WebMvcConfigurerAdapter {
       })
 
     return factory
+  }
+
+  @Override
+  void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(new BrokenInterceptor())
+  }
+
+  public static class BrokenInterceptor extends HandlerInterceptorAdapter {
+    @Override
+    boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+      if ((handler as HandlerMethod).method.name == 'broken') {
+        throw new IllegalArgumentException("Broken interceptor")
+      }
+      return true;
+    }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -7,6 +7,7 @@ import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.asserts.SpanAssert
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.utils.ConfigUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -27,6 +28,18 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCES
 import static java.util.Collections.singletonMap
 
 class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext> {
+
+  static {
+    ConfigUtils.updateConfig {
+      System.setProperty("dd.trace.classes.exclude", 'org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration$WelcomePageHandlerMapping')
+    }
+  }
+
+  def cleanupSpec(){
+    ConfigUtils.updateConfig {
+      System.clearProperty("dd.trace.classes.exclude")
+    }
+  }
 
   def "allowedExceptions=IllegalArgument should tag error=#error when exception=#exception is thrown"() {
     setup:

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/TestController.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/TestController.groovy
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
@@ -72,5 +73,11 @@ class TestController {
     } else {
       new ResponseEntity(throwable.message, HttpStatus.INTERNAL_SERVER_ERROR)
     }
+  }
+
+  @RequestMapping("/broken/{variable}")
+  @ResponseBody
+  String broken(@PathVariable String variable) {
+    return variable
   }
 }


### PR DESCRIPTION
This works around the issue in SWAT-1755 ticket, where span name was not updated if some `HandlerInterceptor` throws an exception from `preHandle`