### PR TITLE
Version 0.48.0-sfx1

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -184,7 +184,7 @@ public class Config {
   public static final String TRACING_LIBRARY_KEY = "signalfx.tracing.library";
   public static final String TRACING_LIBRARY_VALUE = "java-tracing";
   public static final String TRACING_VERSION_KEY = "signalfx.tracing.version";
-  public static final String TRACING_VERSION_VALUE = "0.48.0-sfx0";
+  public static final String TRACING_VERSION_VALUE = "0.48.0-sfx1";
 
   private static final boolean DEFAULT_TRACE_ENABLED = true;
   public static final boolean DEFAULT_INTEGRATIONS_ENABLED = true;

--- a/signalfx-java-tracing.gradle
+++ b/signalfx-java-tracing.gradle
@@ -34,7 +34,7 @@ scmVersion {
 allprojects {
   group = 'com.signalfx.public'
   // Don't forget to update TRACING_VERSION_VALUE in dd-trace-api/src/main/java/datadog/trace/api/Config.java
-  version = '0.48.0-sfx0'
+  version = '0.48.0-sfx1'
 
   if (isCI) {
     buildDir = "${rootDir}/workspace/${projectDir.path.replace(rootDir.path, '')}/build/"


### PR DESCRIPTION
- Optionally pass trace context in http response via Server-Timing
- Add a separate HandlerMappingInstrumentation to update server span name when the corresponding handler got selected