### PR TITLE
Avoid doubly tracing MongoClientSettingsBuilder

### DIFF
--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/main/java/datadog/trace/instrumentation/mongo/MongoClientInstrumentation.java
@@ -62,8 +62,9 @@ public final class MongoClientInstrumentation extends Instrumenter.Default {
   public static class MongoClientAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void injectTraceListener(@Advice.This final Object dis,
-                                           @Advice.FieldValue("commandListeners") final List<CommandListener> commandListeners) {
+    public static void injectTraceListener(
+        @Advice.This final Object dis,
+        @Advice.FieldValue("commandListeners") final List<CommandListener> commandListeners) {
       for (final CommandListener commandListener : commandListeners) {
         if (commandListener instanceof TracingCommandListener) {
           return;

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoClientTest.groovy
@@ -57,6 +57,30 @@ class MongoClientTest extends MongoBaseTest {
     renameService << [false, true]
   }
 
+  // Tests the fix for double-tracing, based on a similar fixed applied to opentelemetry-java-instrumentation
+  // TracingCommandListener might get added multiple times if ClientSettings are built using existing ClientSettings or when calling  a build method twice.
+  // This test asserts that duplicate traces are not created in those cases.
+  def "test create collection with already built ClientOptions"() {
+    setup:
+    def clientOptions = client.mongoClientOptions
+    def newClientOptions = MongoClientOptions.builder(clientOptions).build()
+    MongoDatabase db = new MongoClient(new ServerAddress("localhost", port), newClientOptions).getDatabase(dbName)
+
+    when:
+    db.createCollection(collectionName)
+
+    then:
+    assertTraces(1) {
+      trace(0, 1) {
+        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}")
+      }
+    }
+
+    where:
+    dbName = "test_db"
+    collectionName = "testCollection"
+  }
+
   def "test create collection no description"() {
     setup:
     MongoDatabase db = new MongoClient("localhost", port).getDatabase(dbName)

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/main/java/datadog/trace/instrumentation/mongo/MongoAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/main/java/datadog/trace/instrumentation/mongo/MongoAsyncClientInstrumentation.java
@@ -62,8 +62,9 @@ public final class MongoAsyncClientInstrumentation extends Instrumenter.Default 
   public static class MongoAsyncClientAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void injectTraceListener(@Advice.This final Object dis,
-                                           @Advice.FieldValue("commandListeners") final List<CommandListener> commandListeners) {
+    public static void injectTraceListener(
+        @Advice.This final Object dis,
+        @Advice.FieldValue("commandListeners") final List<CommandListener> commandListeners) {
       for (final CommandListener commandListener : commandListeners) {
         if (commandListener instanceof TracingCommandListener) {
           return;

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/main/java/datadog/trace/instrumentation/mongo/MongoAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/main/java/datadog/trace/instrumentation/mongo/MongoAsyncClientInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.mongo;
 
 import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.declaresField;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -9,9 +10,11 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import com.mongodb.async.client.MongoClientSettings;
+import com.mongodb.event.CommandListener;
 import datadog.trace.agent.tooling.Instrumenter;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -38,7 +41,8 @@ public final class MongoAsyncClientInstrumentation extends Instrumenter.Default 
                                 Modifier.PUBLIC,
                                 null,
                                 Collections.<TypeDescription.Generic>emptyList())))
-                    .and(isPublic())));
+                    .and(isPublic())))
+        .and(declaresField(named("commandListeners")));
   }
 
   @Override
@@ -58,7 +62,13 @@ public final class MongoAsyncClientInstrumentation extends Instrumenter.Default 
   public static class MongoAsyncClientAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void injectTraceListener(@Advice.This final Object dis) {
+    public static void injectTraceListener(@Advice.This final Object dis,
+                                           @Advice.FieldValue("commandListeners") final List<CommandListener> commandListeners) {
+      for (final CommandListener commandListener : commandListeners) {
+        if (commandListener instanceof TracingCommandListener) {
+          return;
+        }
+      }
       // referencing "this" in the method args causes the class to load under a transformer.
       // This bypasses the Builder instrumentation. Casting as a workaround.
       final MongoClientSettings.Builder builder = (MongoClientSettings.Builder) dis;

--- a/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -68,6 +68,34 @@ class MongoAsyncClientTest extends MongoBaseTest {
     collectionName = "testCollection"
   }
 
+  // Tests the fix for double-tracing, based on a similar fixed applied to opentelemetry-java-instrumentation
+  // TracingCommandListener might get added multiple times if ClientSettings are built using existing ClientSettings or when calling a build method twice.
+  // This test asserts that duplicate traces are not created in those cases.
+  def "test create collection with already built ClientSettings"() {
+    setup:
+    def clientSettings = client.settings
+    def newClientSettings = MongoClientSettings.builder(clientSettings).build()
+    MongoDatabase db = MongoClients.create(newClientSettings).getDatabase(dbName)
+
+    when:
+    db.createCollection(collectionName, toCallback {})
+
+    then:
+    assertTraces(1) {
+      trace(0, 1) {
+        mongoSpan(it, 0) {
+          assert it.replaceAll(" ", "") == "{\"create\":\"$collectionName\",\"capped\":\"?\"}" ||
+            it == "{\"create\": \"$collectionName\", \"capped\": \"?\", \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
+          true
+        }
+      }
+    }
+
+    where:
+    dbName = "test_db"
+    collectionName = "testCollection"
+  }
+
   def "test create collection no description"() {
     setup:
     MongoDatabase db = MongoClients.create("mongodb://localhost:$port").getDatabase(dbName)


### PR DESCRIPTION
Fixes #122: Mongo instrumentation may duplicate traced command spans

Check for already injected TracingCommandListener before injecting.
Patch derived from the fix for a similar issue in open-telemetry/opentelemetry-java-instrumentation.