### PR TITLE
Fix #124: Enable priority samplers to drop traces

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
@@ -30,9 +30,8 @@ public class RateByServiceSampler implements Sampler, PrioritySampler, ResponseL
 
   @Override
   public boolean sample(final DDSpan span) {
-    // Priority sampling sends all traces to the core agent, including traces marked dropped.
-    // This allows the core agent to collect stats on all traces.
-    return true;
+    final Integer samplingPriority = span.getSamplingPriority();
+    return (samplingPriority != null && samplingPriority > 0);
   }
 
   /** If span is a root span, set the span context samplingPriority to keep or drop */

--- a/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RuleBasedSampler.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/sampling/RuleBasedSampler.java
@@ -77,7 +77,8 @@ public class RuleBasedSampler implements Sampler, PrioritySampler {
 
   @Override
   public boolean sample(final DDSpan span) {
-    return true;
+    final Integer samplingPriority = span.getSamplingPriority();
+    return (samplingPriority != null && samplingPriority > 0);
   }
 
   @Override


### PR DESCRIPTION
This patch ensures that Rate-By-Service and Rule-Based samplers drop traces as configured, or when spans set `manual.drop` or `manual.keep`. The behavior of the default "All" Sampler is not changed.