### PR TITLE
Version 0.48.0-sfx2

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -184,7 +184,7 @@ public class Config {
   public static final String TRACING_LIBRARY_KEY = "signalfx.tracing.library";
   public static final String TRACING_LIBRARY_VALUE = "java-tracing";
   public static final String TRACING_VERSION_KEY = "signalfx.tracing.version";
-  public static final String TRACING_VERSION_VALUE = "0.48.0-sfx1";
+  public static final String TRACING_VERSION_VALUE = "0.48.0-sfx2";
 
   private static final boolean DEFAULT_TRACE_ENABLED = true;
   public static final boolean DEFAULT_INTEGRATIONS_ENABLED = true;

--- a/signalfx-java-tracing.gradle
+++ b/signalfx-java-tracing.gradle
@@ -34,7 +34,7 @@ scmVersion {
 allprojects {
   group = 'com.signalfx.public'
   // Don't forget to update TRACING_VERSION_VALUE in dd-trace-api/src/main/java/datadog/trace/api/Config.java
-  version = '0.48.0-sfx1'
+  version = '0.48.0-sfx2'
 
   if (isCI) {
     buildDir = "${rootDir}/workspace/${projectDir.path.replace(rootDir.path, '')}/build/"


### PR DESCRIPTION
- Camel instrumentation
- Avoid doubly tracing MongoClientSettingsBuilder