### PR TITLE
upgrade jackson-databind to latest.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
     okhttp     : "3.12.8", // 3.12.x is last version to support Java7)
 
     // When upgrading for security fixes, ensure corresponding change is reflected in jmxfetch.
-    jackson    : "2.10.0", // https://nvd.nist.gov/vuln/detail/CVE-2019-16942 et al
+    jackson    : "2.12.0", // https://nvd.nist.gov/vuln/detail/CVE-2019-16942 et al
 
     spock      : "1.3-groovy-$spockGroovyVer",
     groovy     : groovyVer,


### PR DESCRIPTION
Mitigates CVE-2019-14893, CVE-2020-25649, and possibly others