### PR TITLE
🌶️  Update to latest jmxfetch upstream 🌶️

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,7 +4,7 @@ plugins {
 apply from: "${rootDir}/gradle/java.gradle"
 
 dependencies {
-  compile('com.datadoghq:jmxfetch:0.35.0') {
+  compile('com.datadoghq:jmxfetch:0.41.0') {
     exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
     exclude group: 'org.slf4j', module: 'slf4j-api'
@@ -12,6 +12,7 @@ dependencies {
   }
   compile deps.slf4j
   compile project(':dd-trace-api')
+  compile group: 'commons-io', name: 'commons-io', version: '2.4'
   compile group: 'org.yaml', name: 'snakeyaml', version: '1.27'
 }
 

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -2,18 +2,13 @@ package datadog.trace.agent.jmxfetch;
 
 import static org.datadog.jmxfetch.AppConfig.ACTION_COLLECT;
 
-import com.google.common.collect.ImmutableList;
 import datadog.trace.api.Config;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.*;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.datadog.jmxfetch.App;
@@ -23,8 +18,8 @@ import org.datadog.jmxfetch.reporter.ReporterFactory;
 @Slf4j
 public class JMXFetch {
 
-  public static final ImmutableList<String> DEFAULT_CONFIGS =
-      ImmutableList.of("jmxfetch-config.yaml");
+  public static final List<String> DEFAULT_CONFIGS =
+      Collections.unmodifiableList(Arrays.asList("jmxfetch-config.yaml"));
 
   private static final int SLEEP_AFTER_JMXFETCH_EXITS = 5000;
 
@@ -69,7 +64,7 @@ public class JMXFetch {
 
     final AppConfig.AppConfigBuilder configBuilder =
         AppConfig.builder()
-            .action(ImmutableList.of(ACTION_COLLECT))
+            .action(Collections.unmodifiableList(Arrays.asList(ACTION_COLLECT)))
             // App should be run as daemon otherwise CLI apps would not exit once main method exits.
             .daemon(true)
             .confdDirectory(jmxFetchConfigDir)

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -19,7 +19,7 @@ import org.datadog.jmxfetch.reporter.ReporterFactory;
 public class JMXFetch {
 
   public static final List<String> DEFAULT_CONFIGS =
-      Collections.unmodifiableList(Arrays.asList("jmxfetch-config.yaml"));
+      Collections.singletonList("jmxfetch-config.yaml");
 
   private static final int SLEEP_AFTER_JMXFETCH_EXITS = 5000;
 
@@ -64,7 +64,7 @@ public class JMXFetch {
 
     final AppConfig.AppConfigBuilder configBuilder =
         AppConfig.builder()
-            .action(Collections.unmodifiableList(Arrays.asList(ACTION_COLLECT)))
+            .action(Collections.singletonList(ACTION_COLLECT))
             // App should be run as daemon otherwise CLI apps would not exit once main method exits.
             .daemon(true)
             .confdDirectory(jmxFetchConfigDir)


### PR DESCRIPTION
...and mitigate transitive jackson vulns.

Noting this as spicy, since [quite a few changes were made in jmxfetch](https://github.com/DataDog/jmxfetch/blob/master/CHANGELOG.md) since `0.35.0`.

Upstream lost a number of dependencies, including `jackson-databind` and `commons-io` (and several others).  As a result, we have to now depend on `commons-io` directly (for IOUtils).