### PR TITLE
Expose service name and environment via MDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ over corresponding environment variables.
 | System property | Environment variable | Default value | Notes |
 | ---             | ---                  | ---           | ---   |
 | `signalfx.service.name` | `SIGNALFX_SERVICE_NAME` | `"unnamed-java-service"` | The name of the service. |
-| `signalfx.environment.name` | `SIGNALFX_ENVIRONMENT_NAME` | `""` | Service environment. If set will be part of the span tag as `environment`. |
+| `signalfx.env` | `SIGNALFX_ENV` | `""` | Service environment. If set will be part of the span tag as `environment`. |
 | `signalfx.agent.host` | `SIGNALFX_AGENT_HOST` | `"localhost"` | The endpoint for a SignalFx Smart Agent or OpenTelemetry Collector. |
 | `signalfx.endpoint.url` | `SIGNALFX_ENDPOINT_URL` | `"http://localhost:9080/v1/trace"` | Takes priority over constituent Agent properties. |
 | `signalfx.tracing.enabled` | `SIGNALFX_TRACING_ENABLED` | `"true"` | Globally enables tracer creation and auto-instrumentation.  Any value not matching `"true"` is treated as false (`Boolean.valueOf()`). |
@@ -156,7 +156,7 @@ The MDC add following fields to log events:
 - `signalfx.trace_id`
 - `signalfx.span_id`
 - `signalfx.service` - Value of `signalfx.service.name` property.
-- `signalfx.environment` - Value of `signalfx.environment.name` property.
+- `signalfx.environment` - Value of `signalfx.env` property.
 
 Injection uses `java.util.logging` with a `logback`, `log4j`, or `slf4j` logging framework. 
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ the table.
 | Kafka Client | 0.11.0.0+ | `kafka` | Disable trace propagation for unsupported environments with `-Dsignalfx.instrumentation.kafka.attempt-propagation=false`. |
 | khttp | 0.1.0+ | `khttp` | |
 | Lettuce (Redis Client) | 5.0.0+ | `lettuce` | Prevent command arguments from being sourced in `db.statement` tag with `-Dsignalfx.instrumentation.redis.capture-command-arguments=false`. |
-| _Java MDC_ | * | `-Dsignalfx.logs.injection=true` on Java invocation | Injects `signalfx.trace_id` and `signalfx.span_id` to MDC contexts. |
+| _Java MDC_ | * | `-Dsignalfx.logs.injection=true` on Java invocation | Injects `signalfx.trace_id`, `signalfx.span_id`, `signalfx.service`, `signalfx.environment` to MDC contexts. |
 | Memcached (SpyMemcached) | 2.10.0+ | `spymemcached` | |
 | Mongo Client | 3.1+ | `mongo` | |
 | Mongo Async Client | 3.3+ | `mongo` | |
@@ -109,6 +109,7 @@ over corresponding environment variables.
 | System property | Environment variable | Default value | Notes |
 | ---             | ---                  | ---           | ---   |
 | `signalfx.service.name` | `SIGNALFX_SERVICE_NAME` | `"unnamed-java-service"` | The name of the service. |
+| `signalfx.environment.name` | `SIGNALFX_ENVIRONMENT_NAME` | `""` | Service environment. If set will be part of the span tag as `environment`. |
 | `signalfx.agent.host` | `SIGNALFX_AGENT_HOST` | `"localhost"` | The endpoint for a SignalFx Smart Agent or OpenTelemetry Collector. |
 | `signalfx.endpoint.url` | `SIGNALFX_ENDPOINT_URL` | `"http://localhost:9080/v1/trace"` | Takes priority over constituent Agent properties. |
 | `signalfx.tracing.enabled` | `SIGNALFX_TRACING_ENABLED` | `"true"` | Globally enables tracer creation and auto-instrumentation.  Any value not matching `"true"` is treated as false (`Boolean.valueOf()`). |
@@ -143,7 +144,7 @@ Set this environment variable from the command line:
     $ java -javaagent:path/to/signalfx-tracing.jar -jar app.jar
     ```
 
-## Inject trace IDs in logs
+## Inject trace context into logs
 
 Link individual log entries with trace IDs and span IDs associated with
 corresponding events. The SignalFx Java Agent uses a
@@ -151,10 +152,13 @@ corresponding events. The SignalFx Java Agent uses a
 (MDC), an open standard for identifying interleaved log outputs from multiple
 sources.
 
-The MDC adds the `signalfx.trace_id` and `signalfx.span_id` fields to log events.
+The MDC add following fields to log events:
+- `signalfx.trace_id`
+- `signalfx.span_id`
+- `signalfx.service` - Value of `signalfx.service.name` property.
+- `signalfx.environment` - Value of `signalfx.environment.name` property.
 
-Trace ID injection uses `java.util.logging` with a `logback`, `log4j`, or
-`slf4j` logging framework. 
+Injection uses `java.util.logging` with a `logback`, `log4j`, or `slf4j` logging framework. 
 
 `java.util.logging` doesn't support MDC on its own. If you aren't using one of
 these frameworks, use a [jul-to-slf4j bridge](http://www.slf4j.org/legacy.html#jul-to-slf4j).
@@ -179,8 +183,8 @@ Follow these steps to inject trace IDs in logs with a `logback`, `log4j`, or
    ```
    logging.pattern.console= %d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg %X %n
    ```
-   The MDC replaces `%X` with the `signalfx.trace_id` and `signalfx.span_id`
-   associated with the log event.
+   The MDC replaces `%X` with the `signalfx.trace_id`, `signalfx.span_id`,
+   `signalfx.service`, `signalfx.environment` associated with the log event.
 4. Update any other services that use the logging pattern to be aware of the
    new logging pattern format as necessary.
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
@@ -30,6 +30,10 @@ public class LogContextScopeListener implements ScopeListener {
           null, CorrelationIdentifier.getTraceIdKey(), CorrelationIdentifier.getTraceId());
       putMethod.invoke(
           null, CorrelationIdentifier.getSpanIdKey(), CorrelationIdentifier.getSpanId());
+      putMethod.invoke(
+          null, CorrelationIdentifier.getServiceNameKey(), CorrelationIdentifier.getServiceName());
+      putMethod.invoke(
+            null, CorrelationIdentifier.getEnvironmentNameKey(), CorrelationIdentifier.getEnvironmentName());
     } catch (final Exception e) {
       log.debug("Exception setting log context context", e);
     }
@@ -40,6 +44,8 @@ public class LogContextScopeListener implements ScopeListener {
     try {
       removeMethod.invoke(null, CorrelationIdentifier.getTraceIdKey());
       removeMethod.invoke(null, CorrelationIdentifier.getSpanIdKey());
+      removeMethod.invoke(null, CorrelationIdentifier.getServiceNameKey());
+      removeMethod.invoke(null, CorrelationIdentifier.getEnvironmentNameKey());
     } catch (final Exception e) {
       log.debug("Exception removing log context context", e);
     }

--- a/dd-java-agent/instrumentation/commons-httpclient-2/commons-httpclient-2.gradle
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/commons-httpclient-2.gradle
@@ -5,6 +5,7 @@ muzzle {
     module = "commons-httpclient"
     versions = "[2.0,]"
     skipVersions += "3.1-jenkins-1" // odd version in jcenter
+    skipVersions += "20020423" // ancient pre-release version
     assertInverse = true
   }
 }
@@ -23,5 +24,5 @@ dependencies {
 
   testCompile group: 'commons-httpclient', name: 'commons-httpclient', version: '2.0'
 
-  latestDepTestCompile group: 'commons-httpclient', name: 'commons-httpclient', version: '+'
+  latestDepTestCompile group: 'commons-httpclient', name: 'commons-httpclient', version: '(2.0,20000000]'
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/log/injection/LogContextInjectionTestBase.groovy
@@ -33,7 +33,7 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     }
   }
 
-  def "Log context shows trace and span ids for active scope"() {
+  def "Log context shows trace info for active scope"() {
     when:
     put("foo", "bar")
     AgentSpan rootSpan = startSpan("root")
@@ -42,6 +42,8 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     then:
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
     get(CorrelationIdentifier.getSpanIdKey()) == CorrelationIdentifier.getSpanId()
+    get(CorrelationIdentifier.getServiceNameKey()) == CorrelationIdentifier.getServiceName()
+    get(CorrelationIdentifier.getEnvironmentNameKey()) == CorrelationIdentifier.getEnvironmentName()
     get("foo") == "bar"
 
     when:
@@ -51,6 +53,8 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     then:
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
     get(CorrelationIdentifier.getSpanIdKey()) == CorrelationIdentifier.getSpanId()
+    get(CorrelationIdentifier.getServiceNameKey()) == CorrelationIdentifier.getServiceName()
+    get(CorrelationIdentifier.getEnvironmentNameKey()) == CorrelationIdentifier.getEnvironmentName()
     get("foo") == "bar"
 
     when:
@@ -59,6 +63,8 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     then:
     get(CorrelationIdentifier.getTraceIdKey()) == CorrelationIdentifier.getTraceId()
     get(CorrelationIdentifier.getSpanIdKey()) == CorrelationIdentifier.getSpanId()
+    get(CorrelationIdentifier.getServiceNameKey()) == CorrelationIdentifier.getServiceName()
+    get(CorrelationIdentifier.getEnvironmentNameKey()) == CorrelationIdentifier.getEnvironmentName()
     get("foo") == "bar"
 
     when:
@@ -67,6 +73,8 @@ abstract class LogContextInjectionTestBase extends AgentTestRunner {
     then:
     get(CorrelationIdentifier.getTraceIdKey()) == null
     get(CorrelationIdentifier.getSpanIdKey()) == null
+    get(CorrelationIdentifier.getServiceNameKey()) == null
+    get(CorrelationIdentifier.getEnvironmentNameKey()) == null
     get("foo") == "bar"
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -61,6 +61,7 @@ public class Config {
   public static final String API_KEY_FILE = "api-key-file";
   public static final String SITE = "site";
   public static final String SERVICE_NAME = "service.name";
+  public static final String ENVIRONMENT_NAME = "environment.name";
   public static final String TRACE_ENABLED = "tracing.enabled";
   public static final String INTEGRATIONS_ENABLED = "integrations.enabled";
   public static final String WRITER_TYPE = "writer.type";
@@ -165,6 +166,7 @@ public class Config {
   public static final String RUNTIME_ID_TAG = "runtime-id";
   public static final String SERVICE = "service";
   public static final String SERVICE_TAG = SERVICE;
+  public static final String ENVIRONMENT_TAG = "environment";
   public static final String HOST_TAG = "host";
   public static final String LANGUAGE_TAG_KEY = "language";
   public static final String LANGUAGE_TAG_VALUE = "jvm";
@@ -292,6 +294,7 @@ public class Config {
   @Getter private final String site;
 
   @Getter private final String serviceName;
+  @Getter private final String environmentName;
   @Getter private final boolean traceEnabled;
   @Getter private final boolean integrationsEnabled;
   @Getter private final String writerType;
@@ -415,6 +418,8 @@ public class Config {
     serviceName =
         getSettingFromEnvironment(
             SERVICE_NAME, getSettingFromEnvironment(SERVICE, DEFAULT_SERVICE_NAME));
+
+    environmentName = getSettingFromEnvironment(ENVIRONMENT_NAME, "");
 
     traceEnabled = getBooleanSettingFromEnvironment(TRACE_ENABLED, DEFAULT_TRACE_ENABLED);
     integrationsEnabled =
@@ -633,6 +638,7 @@ public class Config {
     apiKey = properties.getProperty(API_KEY, parent.apiKey);
     site = properties.getProperty(SITE, parent.site);
     serviceName = properties.getProperty(SERVICE_NAME, parent.serviceName);
+    environmentName = properties.getProperty(ENVIRONMENT_NAME, parent.environmentName);
 
     traceEnabled = getPropertyBooleanValue(properties, TRACE_ENABLED, parent.traceEnabled);
     integrationsEnabled =
@@ -830,6 +836,11 @@ public class Config {
     final Map<String, String> result = new HashMap<>(runtimeTags);
     result.put(TRACING_LIBRARY_KEY, TRACING_LIBRARY_VALUE);
     result.put(TRACING_VERSION_KEY, TRACING_VERSION_VALUE);
+
+    String environment = getEnvironmentName();
+    if (!environment.isEmpty()) {
+      result.put(ENVIRONMENT_TAG, environment);
+    }
 
     if (reportHostName) {
       final String hostName = getHostName();

--- a/dd-trace-api/src/main/java/datadog/trace/api/CorrelationIdentifier.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/CorrelationIdentifier.java
@@ -22,9 +22,13 @@ public class CorrelationIdentifier {
     return SPAN_ID_KEY;
   }
 
-  public static String getServiceNameKey() { return SERVICE_NAME_KEY; }
+  public static String getServiceNameKey() {
+    return SERVICE_NAME_KEY;
+  }
 
-  public static String getEnvironmentNameKey() { return ENVIRONMENT_NAME_KEY; }
+  public static String getEnvironmentNameKey() {
+    return ENVIRONMENT_NAME_KEY;
+  }
 
   public static String getTraceId() {
     return Ids.idToHex(GlobalTracer.get().getTraceId());
@@ -34,7 +38,11 @@ public class CorrelationIdentifier {
     return Ids.idToHex(GlobalTracer.get().getSpanId());
   }
 
-  public static String getServiceName() { return GlobalTracer.get().getServiceName(); }
+  public static String getServiceName() {
+    return GlobalTracer.get().getServiceName();
+  }
 
-  public static String getEnvironmentName() { return GlobalTracer.get().getEnvironmentName(); }
+  public static String getEnvironmentName() {
+    return GlobalTracer.get().getEnvironmentName();
+  }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/CorrelationIdentifier.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/CorrelationIdentifier.java
@@ -9,6 +9,8 @@ package datadog.trace.api;
 public class CorrelationIdentifier {
   private static final String TRACE_ID_KEY = "signalfx.trace_id";
   private static final String SPAN_ID_KEY = "signalfx.span_id";
+  private static final String SERVICE_NAME_KEY = "signalfx.service";
+  private static final String ENVIRONMENT_NAME_KEY = "signalfx.environment";
 
   /** @return The trace-id key to use with datadog logs integration */
   public static String getTraceIdKey() {
@@ -20,6 +22,10 @@ public class CorrelationIdentifier {
     return SPAN_ID_KEY;
   }
 
+  public static String getServiceNameKey() { return SERVICE_NAME_KEY; }
+
+  public static String getEnvironmentNameKey() { return ENVIRONMENT_NAME_KEY; }
+
   public static String getTraceId() {
     return Ids.idToHex(GlobalTracer.get().getTraceId());
   }
@@ -27,4 +33,8 @@ public class CorrelationIdentifier {
   public static String getSpanId() {
     return Ids.idToHex(GlobalTracer.get().getSpanId());
   }
+
+  public static String getServiceName() { return GlobalTracer.get().getServiceName(); }
+
+  public static String getEnvironmentName() { return GlobalTracer.get().getEnvironmentName(); }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
@@ -24,6 +24,12 @@ public class GlobalTracer {
         }
 
         @Override
+        public String getServiceName() { return ""; }
+
+        @Override
+        public String getEnvironmentName() { return ""; }
+
+        @Override
         public boolean addTraceInterceptor(TraceInterceptor traceInterceptor) {
           return false;
         }

--- a/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
@@ -24,10 +24,14 @@ public class GlobalTracer {
         }
 
         @Override
-        public String getServiceName() { return ""; }
+        public String getServiceName() {
+          return "";
+        }
 
         @Override
-        public String getEnvironmentName() { return ""; }
+        public String getEnvironmentName() {
+          return "";
+        }
 
         @Override
         public boolean addTraceInterceptor(TraceInterceptor traceInterceptor) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
@@ -14,6 +14,10 @@ public interface Tracer {
    */
   String getSpanId();
 
+  String getServiceName();
+
+  String getEnvironmentName();
+
   /**
    * Add a new interceptor to the tracer. Interceptors with duplicate priority to existing ones are
    * ignored.

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -20,6 +20,7 @@ import static datadog.trace.api.Config.CONFIGURATION_FILE
 import static datadog.trace.api.Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 import static datadog.trace.api.Config.DEFAULT_JMX_FETCH_STATSD_PORT
 import static datadog.trace.api.Config.DEFAULT_KAFKA_ATTEMPT_PROPAGATION
+import static datadog.trace.api.Config.ENVIRONMENT_NAME
 import static datadog.trace.api.Config.GLOBAL_TAGS
 import static datadog.trace.api.Config.HEADER_TAGS
 import static datadog.trace.api.Config.HOST_TAG
@@ -67,6 +68,7 @@ import static datadog.trace.api.Config.SIGNALFX_PREFIX
 import static datadog.trace.api.Config.SERVICE_MAPPING
 import static datadog.trace.api.Config.SERVICE_NAME
 import static datadog.trace.api.Config.SERVICE_TAG
+import static datadog.trace.api.Config.ENVIRONMENT_TAG
 import static datadog.trace.api.Config.SITE
 import static datadog.trace.api.Config.SPAN_TAGS
 import static datadog.trace.api.Config.SPLIT_BY_TAGS
@@ -95,6 +97,7 @@ class ConfigTest extends DDSpecification {
 
   private static final DD_API_KEY_ENV = "DD_API_KEY"
   private static final DD_SERVICE_NAME_ENV = "DD_SERVICE_NAME"
+  private static final DD_ENVIRONMENT_NAME_ENV = "DD_ENVIRONMENT_NAME"
   private static final DD_TRACE_ENABLED_ENV = "DD_TRACING_ENABLED"
   private static final DD_WRITER_TYPE_ENV = "DD_WRITER_TYPE"
   private static final DD_SERVICE_MAPPING_ENV = "DD_SERVICE_MAPPING"
@@ -129,6 +132,7 @@ class ConfigTest extends DDSpecification {
     config.apiKey == null
     config.site == Config.DEFAULT_SITE
     config.serviceName == "unnamed-java-service"
+    config.environmentName == ""
     config.traceEnabled == true
     config.writerType == "DDAgentWriter"
     config.apiType == "ZipkinV2"
@@ -200,6 +204,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(API_KEY, "new api key")
     prop.setProperty(SITE, "new site")
     prop.setProperty(SERVICE_NAME, "something else")
+    prop.setProperty(ENVIRONMENT_NAME, "test-env")
     prop.setProperty(TRACE_ENABLED, "false")
     prop.setProperty(WRITER_TYPE, "LoggingWriter")
     prop.setProperty(AGENT_HOST, "somehost")
@@ -262,6 +267,7 @@ class ConfigTest extends DDSpecification {
     config.apiKey == "new api key" // we can still override via internal properties object
     config.site == "new site"
     config.serviceName == "something else"
+    config.environmentName == "test-env"
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
     config.agentHost == "somehost"
@@ -272,6 +278,7 @@ class ConfigTest extends DDSpecification {
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (SERVICE): config.serviceName]
+    config.getLocalRootSpanTags().get(ENVIRONMENT_TAG) == config.environmentName
     config.headerTags == [e: "5"]
     config.httpServerErrorStatuses == (122..457).toSet()
     config.httpClientErrorStatuses == (111..111).toSet()
@@ -322,6 +329,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(prefix + API_KEY, "new api key")
     System.setProperty(prefix + SITE, "new site")
     System.setProperty(prefix + SERVICE_NAME, "something else") // SFX
+    System.setProperty(prefix + ENVIRONMENT_NAME, "test-env")
     System.setProperty(prefix + TRACE_ENABLED, "false")
     System.setProperty(prefix + WRITER_TYPE, "LoggingWriter") // SFX
     System.setProperty(prefix + USE_B3_PROPAGATION, "false") // SFX
@@ -393,6 +401,7 @@ class ConfigTest extends DDSpecification {
     config.apiKey == null // system properties cannot be used to provide a key
     config.site == "new site"
     config.serviceName == "something else"
+    config.environmentName == "test-env"
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
     config.useB3Propagation == false
@@ -460,6 +469,7 @@ class ConfigTest extends DDSpecification {
     setup:
     environmentVariables.set(DD_API_KEY_ENV, "test-api-key")
     environmentVariables.set(DD_SERVICE_NAME_ENV, "still something else")
+    environmentVariables.set(DD_ENVIRONMENT_NAME_ENV, "different")
     environmentVariables.set(DD_TRACE_ENABLED_ENV, "false")
     environmentVariables.set(DD_WRITER_TYPE_ENV, "LoggingWriter")
     environmentVariables.set(DD_PROPAGATION_STYLE_EXTRACT, "B3 Datadog")
@@ -478,6 +488,7 @@ class ConfigTest extends DDSpecification {
     then:
     config.apiKey == "test-api-key"
     config.serviceName == "still something else"
+    config.environmentName == "different"
     config.traceEnabled == false
     config.writerType == "LoggingWriter"
     config.propagationStylesToExtract.toList() == [Config.PropagationStyle.B3, Config.PropagationStyle.DATADOG]

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -20,7 +20,7 @@ import static datadog.trace.api.Config.CONFIGURATION_FILE
 import static datadog.trace.api.Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 import static datadog.trace.api.Config.DEFAULT_JMX_FETCH_STATSD_PORT
 import static datadog.trace.api.Config.DEFAULT_KAFKA_ATTEMPT_PROPAGATION
-import static datadog.trace.api.Config.ENVIRONMENT_NAME
+import static datadog.trace.api.Config.ENV
 import static datadog.trace.api.Config.GLOBAL_TAGS
 import static datadog.trace.api.Config.HEADER_TAGS
 import static datadog.trace.api.Config.HOST_TAG
@@ -68,7 +68,6 @@ import static datadog.trace.api.Config.SIGNALFX_PREFIX
 import static datadog.trace.api.Config.SERVICE_MAPPING
 import static datadog.trace.api.Config.SERVICE_NAME
 import static datadog.trace.api.Config.SERVICE_TAG
-import static datadog.trace.api.Config.ENVIRONMENT_TAG
 import static datadog.trace.api.Config.SITE
 import static datadog.trace.api.Config.SPAN_TAGS
 import static datadog.trace.api.Config.SPLIT_BY_TAGS
@@ -97,7 +96,6 @@ class ConfigTest extends DDSpecification {
 
   private static final DD_API_KEY_ENV = "DD_API_KEY"
   private static final DD_SERVICE_NAME_ENV = "DD_SERVICE_NAME"
-  private static final DD_ENVIRONMENT_NAME_ENV = "DD_ENVIRONMENT_NAME"
   private static final DD_TRACE_ENABLED_ENV = "DD_TRACING_ENABLED"
   private static final DD_WRITER_TYPE_ENV = "DD_WRITER_TYPE"
   private static final DD_SERVICE_MAPPING_ENV = "DD_SERVICE_MAPPING"
@@ -204,7 +202,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(API_KEY, "new api key")
     prop.setProperty(SITE, "new site")
     prop.setProperty(SERVICE_NAME, "something else")
-    prop.setProperty(ENVIRONMENT_NAME, "test-env")
+    prop.setProperty(ENV, "test-env")
     prop.setProperty(TRACE_ENABLED, "false")
     prop.setProperty(WRITER_TYPE, "LoggingWriter")
     prop.setProperty(AGENT_HOST, "somehost")
@@ -276,9 +274,8 @@ class ConfigTest extends DDSpecification {
     config.prioritySamplingEnabled == false
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
-    config.mergedSpanTags == [b: "2", c: "3"]
+    config.mergedSpanTags == [environment: "test-env", b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (SERVICE): config.serviceName]
-    config.getLocalRootSpanTags().get(ENVIRONMENT_TAG) == config.environmentName
     config.headerTags == [e: "5"]
     config.httpServerErrorStatuses == (122..457).toSet()
     config.httpClientErrorStatuses == (111..111).toSet()
@@ -329,7 +326,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(prefix + API_KEY, "new api key")
     System.setProperty(prefix + SITE, "new site")
     System.setProperty(prefix + SERVICE_NAME, "something else") // SFX
-    System.setProperty(prefix + ENVIRONMENT_NAME, "test-env")
+    System.setProperty(prefix + ENV, "test-env")
     System.setProperty(prefix + TRACE_ENABLED, "false")
     System.setProperty(prefix + WRITER_TYPE, "LoggingWriter") // SFX
     System.setProperty(prefix + USE_B3_PROPAGATION, "false") // SFX
@@ -413,7 +410,7 @@ class ConfigTest extends DDSpecification {
     config.prioritySamplingEnabled == false
     config.traceResolverEnabled == false
     config.serviceMapping == [a: "1"]
-    config.mergedSpanTags == [b: "2", c: "3"]
+    config.mergedSpanTags == [environment: "test-env", b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (SERVICE): config.serviceName]
     config.headerTags == [e: "5"]
     config.httpServerErrorStatuses == (122..457).toSet()
@@ -469,7 +466,7 @@ class ConfigTest extends DDSpecification {
     setup:
     environmentVariables.set(DD_API_KEY_ENV, "test-api-key")
     environmentVariables.set(DD_SERVICE_NAME_ENV, "still something else")
-    environmentVariables.set(DD_ENVIRONMENT_NAME_ENV, "different")
+    environmentVariables.set(DD_ENV_ENV, "different")
     environmentVariables.set(DD_TRACE_ENABLED_ENV, "false")
     environmentVariables.set(DD_WRITER_TYPE_ENV, "LoggingWriter")
     environmentVariables.set(DD_PROPAGATION_STYLE_EXTRACT, "B3 Datadog")
@@ -1363,13 +1360,13 @@ class ConfigTest extends DDSpecification {
     setup:
     environmentVariables.set(DD_ENV_ENV, "test_env")
     environmentVariables.set(DD_VERSION_ENV, "1.2.3")
-    environmentVariables.set(DD_TAGS_ENV, "signalfx.env:production   ,    signalfx.version:3.2.1")
+    environmentVariables.set(DD_TAGS_ENV, "environment:production,signalfx.version:3.2.1")
 
     when:
     Config config = new Config()
 
     then:
-    config.mergedSpanTags == ["signalfx.env": "test_env", "signalfx.version": "1.2.3"]
+    config.mergedSpanTags == ["environment": "test_env", "signalfx.version": "1.2.3"]
   }
 
   def "propertyNameToEnvironmentVariableName unit test"() {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -63,6 +63,8 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
 
   /** Default service name if none provided on the trace or span */
   final String serviceName;
+  /** Value of the environment name configuration option */
+  final String environmentName;
   /** Writer is an charge of reporting traces and spans to the desired endpoint */
   final Writer writer;
   /** Sampler defines the sampling policy in order to reduce the number of traces for instance */
@@ -305,6 +307,7 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
     assert taggedHeaders != null;
 
     this.serviceName = serviceName;
+    this.environmentName = config.getEnvironmentName();
     if (writer == null) {
       this.writer = Writer.Builder.forConfig(config);
     } else {
@@ -529,6 +532,16 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, datadog.trace
       return ((DDSpan) activeSpan).getSpanId().toString();
     }
     return "0";
+  }
+
+  @Override
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  @Override
+  public String getEnvironmentName() {
+    return environmentName;
   }
 
   @Override


### PR DESCRIPTION
* New system property / env var: `SIGNALFX_ENVIRONMENT_NAME`. `default: ""`.
* If environment name is set, it is added to span tags as `environment`
* Expose both service name and environment to loggers similar to how trace and span IDs are exposed