### PR TITLE
Omit header values from okhttp exception messages.

### DIFF
--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.datadog.jmxfetch.App;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
@@ -33,7 +33,9 @@ public class LogContextScopeListener implements ScopeListener {
       putMethod.invoke(
           null, CorrelationIdentifier.getServiceNameKey(), CorrelationIdentifier.getServiceName());
       putMethod.invoke(
-            null, CorrelationIdentifier.getEnvironmentNameKey(), CorrelationIdentifier.getEnvironmentName());
+          null,
+          CorrelationIdentifier.getEnvironmentNameKey(),
+          CorrelationIdentifier.getEnvironmentName());
     } catch (final Exception e) {
       log.debug("Exception setting log context context", e);
     }

--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -54,6 +54,7 @@ dependencies {
   compile group: 'com.squareup.moshi', name: 'moshi', version: '1.9.2'
   compile group: 'com.github.jnr', name: 'jnr-unixsocket', version: '0.23'
   compile group: 'com.lmax', name: 'disruptor', version: '3.4.2'
+  compile group:  'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
   testAnnotationProcessor deps.autoservice

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -280,9 +280,10 @@ public class DDAgentApi implements Api {
         .build();
   }
 
-  private static Request.Builder prepareRequest(final HttpUrl url) {
-    final Request.Builder builder =
-        new Request.Builder()
+  private static SafeRequestBuilder prepareRequest(final HttpUrl url) {
+
+    final SafeRequestBuilder builder =
+        new SafeRequestBuilder()
             .url(url)
             .addHeader(DATADOG_META_LANG, "java")
             .addHeader(DATADOG_META_LANG_VERSION, DDTraceOTInfo.JAVA_VERSION)

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ddagent/SafeRequestBuilder.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ddagent/SafeRequestBuilder.java
@@ -1,0 +1,159 @@
+package datadog.trace.common.writer.ddagent;
+
+import java.net.URL;
+import javax.annotation.Nullable;
+import okhttp3.CacheControl;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+/*
+The purpose of this class is to wrap okhttp3.Request.Builder.
+This adapter is used to resolve a vulnerability in Request.builder where
+the .header() and .addHeader() methods can cause header secrets to be
+printed/logged when invalid characters are parsed.
+ */
+public final class SafeRequestBuilder {
+
+  private final Request.Builder requestBuilder;
+
+  public SafeRequestBuilder() {
+    this.requestBuilder = new Request.Builder();
+  }
+
+  // Constructs a SafeRequestBuilder from an existing request
+  public SafeRequestBuilder(Request.Builder request) {
+    this.requestBuilder = request;
+  }
+
+  public SafeRequestBuilder url(HttpUrl url) {
+    this.requestBuilder.url(url);
+    return this;
+  }
+
+  public SafeRequestBuilder url(String url) {
+    this.requestBuilder.url(url);
+    return this;
+  }
+
+  public SafeRequestBuilder url(URL url) {
+    this.requestBuilder.url(url);
+    return this;
+  }
+
+  public SafeRequestBuilder header(String name, String value) {
+    // This try/catch block prevents header secrets from being outputted to
+    // console or logs.
+    try {
+      this.requestBuilder.header(name, value);
+      return this;
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+        new StringBuilder()
+          .append("InvalidArgumentException at header() for header: ")
+          .append(name)
+          .toString());
+    }
+  }
+
+  public SafeRequestBuilder addHeader(String name, String value) {
+    // This try/catch block prevents header secrets from being outputted to
+    // console or logs.
+    try {
+      this.requestBuilder.addHeader(name, value);
+      return this;
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+        new StringBuilder()
+          .append("InvalidArgumentException at addHeader() for header: ")
+          .append(name)
+          .toString());
+    }
+  }
+
+  public static Request.Builder addHeader(Request.Builder builder, String name, String value) {
+    try {
+      return builder.addHeader(name, value);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+        new StringBuilder()
+          .append("InvalidArgumentException at addHeader() for header: ")
+          .append(name)
+          .toString());
+    }
+  }
+
+  public SafeRequestBuilder removeHeader(String name) {
+    this.requestBuilder.removeHeader(name);
+    return this;
+  }
+
+  public SafeRequestBuilder headers(Headers headers) {
+    this.requestBuilder.headers(headers);
+    return this;
+  }
+
+  public SafeRequestBuilder cacheControl(CacheControl cacheControl) {
+    this.requestBuilder.cacheControl(cacheControl);
+    return this;
+  }
+
+  public SafeRequestBuilder get() {
+    this.requestBuilder.get();
+    return this;
+  }
+
+  public SafeRequestBuilder head() {
+    this.requestBuilder.head();
+    return this;
+  }
+
+  public SafeRequestBuilder post(RequestBody body) {
+    this.requestBuilder.post(body);
+    return this;
+  }
+
+  public SafeRequestBuilder delete(@Nullable RequestBody body) {
+    this.requestBuilder.delete(body);
+    return this;
+  }
+
+  public SafeRequestBuilder delete() {
+    this.requestBuilder.delete();
+    return this;
+  }
+
+  public SafeRequestBuilder put(RequestBody body) {
+    this.requestBuilder.put(body);
+    return this;
+  }
+
+  public SafeRequestBuilder patch(RequestBody body) {
+    this.requestBuilder.patch(body);
+    return this;
+  }
+
+  public SafeRequestBuilder method(String method, @Nullable RequestBody body) {
+    this.requestBuilder.method(method, body);
+    return this;
+  }
+
+  public SafeRequestBuilder tag(@Nullable Object tag) {
+    this.requestBuilder.tag(tag);
+    return this;
+  }
+
+  public <T> SafeRequestBuilder tag(Class<? super T> type, @Nullable T tag) {
+    this.requestBuilder.tag(type, tag);
+    return this;
+  }
+
+  public Request build() {
+    return this.requestBuilder.build();
+  }
+
+  public Request.Builder getBuilder() {
+    return this.requestBuilder;
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/trace/common/writer/ddagent/SafeRequestBuilder.java
+++ b/dd-trace-ot/src/main/java/datadog/trace/common/writer/ddagent/SafeRequestBuilder.java
@@ -50,10 +50,10 @@ public final class SafeRequestBuilder {
       return this;
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
-        new StringBuilder()
-          .append("InvalidArgumentException at header() for header: ")
-          .append(name)
-          .toString());
+          new StringBuilder()
+              .append("InvalidArgumentException at header() for header: ")
+              .append(name)
+              .toString());
     }
   }
 
@@ -65,10 +65,10 @@ public final class SafeRequestBuilder {
       return this;
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
-        new StringBuilder()
-          .append("InvalidArgumentException at addHeader() for header: ")
-          .append(name)
-          .toString());
+          new StringBuilder()
+              .append("InvalidArgumentException at addHeader() for header: ")
+              .append(name)
+              .toString());
     }
   }
 
@@ -77,10 +77,10 @@ public final class SafeRequestBuilder {
       return builder.addHeader(name, value);
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
-        new StringBuilder()
-          .append("InvalidArgumentException at addHeader() for header: ")
-          .append(name)
-          .toString());
+          new StringBuilder()
+              .append("InvalidArgumentException at addHeader() for header: ")
+              .append(name)
+              .toString());
     }
   }
 

--- a/dd-trace-ot/src/test/groovy/datadog/trace/common/writer/ddagent/SafeRequestBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/common/writer/ddagent/SafeRequestBuilderTest.groovy
@@ -1,4 +1,4 @@
-package datadog.trace.common.writer.ddagent;
+package datadog.trace.common.writer.ddagent
 
 
 import okhttp3.Headers

--- a/dd-trace-ot/src/test/groovy/datadog/trace/common/writer/ddagent/SafeRequestBuilderTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/trace/common/writer/ddagent/SafeRequestBuilderTest.groovy
@@ -1,0 +1,115 @@
+package datadog.trace.common.writer.ddagent;
+
+
+import okhttp3.Headers
+import okhttp3.MediaType
+import okhttp3.Request
+import okhttp3.RequestBody
+import org.junit.Test
+import org.junit.Assert
+
+class SafeRequestBuilderTest {
+  SafeRequestBuilder testBuilder = new SafeRequestBuilder()
+
+  @Test
+  void "test add header"(){
+    testBuilder.url("http:localhost").addHeader("test","test")
+    Assert.assertEquals(testBuilder.build().headers().get("test"),"test")
+  }
+  @Test
+  void "test remove header"(){
+    testBuilder.url("http:localhost").removeHeader("test")
+    Assert.assertEquals(testBuilder.build().headers().get("test"),null)
+  }
+  @Test
+  void "test static add header"(){
+    Request.Builder builder = new Request.Builder().url("http://localhost")
+    builder = SafeRequestBuilder.addHeader(builder,"test","test")
+    Assert.assertEquals(builder.build().headers().get("test"),"test")
+  }
+  @Test (expected = IllegalArgumentException)
+  void "test bad static add header"(){
+    Request.Builder builder = new Request.Builder().url("http://localhost")
+    builder = SafeRequestBuilder.addHeader(builder,"\n\n","\n\n")
+  }
+  @Test(expected = IllegalArgumentException)
+  void "test adding bad header"(){
+    testBuilder.url("http:localhost").addHeader("\n\n","\n\n")
+  }
+  @Test (expected = IllegalArgumentException)
+  void "test adding bad header2"(){
+    testBuilder.url("localhost").header("\u0019","\u0080")
+  }
+  @Test
+  void "test building result"(){
+    Request testRequest = new SafeRequestBuilder().url("http://localhost")
+      .header("key","value").build()
+    Assert.assertEquals(Request,testRequest.getClass())
+  }
+  @Test
+  void "test getBuilder"(){
+    Request.Builder originalBuilder = new Request.Builder().url("http://localhost")
+      .addHeader("test","test")
+    testBuilder = new SafeRequestBuilder(originalBuilder)
+    Assert.assertEquals(originalBuilder,testBuilder.getBuilder())
+  }
+  @Test
+  void "test get method"(){
+    testBuilder = new SafeRequestBuilder().url("http://localhost")
+    testBuilder.get()
+    testBuilder.headers(new Headers())
+    Assert.assertEquals(testBuilder.build().method(),"GET")
+  }
+  @Test
+  void "test post method"(){
+    testBuilder = new SafeRequestBuilder().url("http://localhost")
+    RequestBody body = RequestBody.create(MediaType.parse("application/json"), "{}")
+    testBuilder.post(body)
+    Assert.assertEquals(testBuilder.build().method(),"POST")
+  }
+  @Test
+  void "test put method"(){
+    testBuilder = new SafeRequestBuilder().url("http://localhost")
+    RequestBody body = RequestBody.create(MediaType.parse("application/json"), "{}")
+    testBuilder.put(body)
+    Assert.assertEquals(testBuilder.build().method(),"PUT")
+  }
+  @Test
+  void "test patch method"(){
+    testBuilder = new SafeRequestBuilder().url("http://localhost")
+    RequestBody body = RequestBody.create(MediaType.parse("application/json"), "{}")
+    testBuilder.patch(body)
+    Assert.assertEquals(testBuilder.build().method(),"PATCH")
+  }
+  @Test
+  void "test delete method"(){
+    testBuilder = new SafeRequestBuilder().url("http://localhost")
+    testBuilder.delete()
+    Assert.assertEquals(testBuilder.build().method(),"DELETE")
+  }
+  @Test
+  void "test method adder"(){
+    testBuilder = new SafeRequestBuilder().url("http://localhost")
+    testBuilder.method("GET",null)
+  }
+  @Test
+  void "test tag"(){
+    testBuilder = new SafeRequestBuilder()
+    URL url = new URL("http://localhost")
+    testBuilder.url(url).tag("test")
+    Assert.assertEquals(testBuilder.build().tag().toString(),"test")
+  }
+  @Test
+  void "test head"(){
+    testBuilder = new SafeRequestBuilder().url("http://localhost")
+    testBuilder.head()
+    Assert.assertEquals(testBuilder.build().method(),"HEAD")
+  }
+  @Test
+  void "test delete with parameter method"(){
+    testBuilder = new SafeRequestBuilder().url("http://localhost")
+    RequestBody body = RequestBody.create(MediaType.parse("application/json"), "{}")
+    testBuilder.delete(body)
+    Assert.assertEquals(testBuilder.build().method(),"DELETE")
+  }
+}


### PR DESCRIPTION
Context 1: https://github.com/square/okhttp/issues/6738#issuecomment-1190949487
Context 2: https://github.com/DataDog/dd-trace-java/pull/3682

This code was forked from the upstream dd repo, so this fix includes the core of the `SafeRequestBuilder` fix in [#3682](https://github.com/DataDog/dd-trace-java/pull/3682).

This applies to api requests that pass through the `DDAgentApi` class. It does not address requests originating in the `RecordingUploader` class (unsupported by Splunk) and it does not address requests originating in user application code.